### PR TITLE
Add patching mechanism to localization

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/BigDoors.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/BigDoors.java
@@ -8,7 +8,7 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.commands.DelayedCommandInputRequest;
 import nl.pim16aap2.bigdoors.commands.IPServer;
 import nl.pim16aap2.bigdoors.doors.DoorOpener;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.logging.IPLogger;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
@@ -153,7 +153,7 @@ public final class BigDoors extends RestartableHolder
         return getPlatform().getDoorSpecificationManager();
     }
 
-    public @NotNull Localizer getLocalizer()
+    public @NotNull ILocalizer getLocalizer()
     {
         return getPlatform().getLocalizer();
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IBigDoorsPlatform.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IBigDoorsPlatform.java
@@ -12,7 +12,7 @@ import nl.pim16aap2.bigdoors.commands.DelayedCommandInputRequest;
 import nl.pim16aap2.bigdoors.commands.IPServer;
 import nl.pim16aap2.bigdoors.doors.DoorOpener;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEvent;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.logging.IPLogger;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
@@ -291,5 +291,5 @@ public interface IBigDoorsPlatform extends IRestartableHolder, IRestartable
      */
     @NotNull LimitsManager getLimitsManager();
 
-    @NotNull Localizer getLocalizer();
+    @NotNull ILocalizer getLocalizer();
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/restartable/RestartableHolder.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/restartable/RestartableHolder.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.api.restartable;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -12,7 +12,7 @@ import java.util.Set;
  */
 public class RestartableHolder implements IRestartableHolder
 {
-    protected final @NotNull Set<@NotNull IRestartable> restartables = new HashSet<>();
+    protected final @NotNull Set<@NotNull IRestartable> restartables = new LinkedHashSet<>();
 
     @Override
     public void registerRestartable(final @NotNull IRestartable restartable)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/ILocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/ILocalizationGenerator.java
@@ -1,0 +1,62 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Represents a type that can be used to generate localization files using properties files from various sources.
+ *
+ * @author Pim
+ */
+interface ILocalizationGenerator
+{
+    /**
+     * Adds a new set of resources to the current localization set.
+     * <p>
+     * When the provided path is a directory, only files of the format "directory/basename[_locale].properties" are
+     * included. "[_locale]" is optional here.
+     * <p>
+     * When the provided path is a file, it is assumed to be a zip file (regardless of its extension, jars would also
+     * work, for example). Only files in the top-level directory of the zip file are considered and of those, only if
+     * they have the format "baseName[_locale].properties". When no specific baseName is provided, the "baseName" part
+     * used as example in the format definition can only contain letters, numbers, and hyphens.
+     *
+     * @param path     The path to a directory containing properties files or the path to a  zip file containing
+     *                 properties files in its top-level directory.
+     * @param baseName The base name of the translation files. When this is null, this property will be ignored and
+     *                 locale files will be appended purely based on their locale.
+     *                 <p>
+     *                 When a baseName is provided, only those files whose names contain only those exact characters or
+     *                 those characters followed by an underscore and the locale are considered. The ".properties" file
+     *                 extension requirement stays either way.
+     */
+    void addResources(@NotNull Path path, @Nullable String baseName);
+
+    /**
+     * Adds locale files from multiple paths.
+     * <p>
+     * This method does not support using base names.
+     * <p>
+     * See {@link #addResources(Path, String)}
+     */
+    void addResources(@NotNull List<Path> paths);
+
+    /**
+     * Loads the locale files from the jar file a specific {@link Class} was loaded from.
+     * <p>
+     * See {@link #addResources(Path, String)}.
+     */
+    void addResourcesFromClass(@NotNull Class<?> clz, @Nullable String baseName);
+
+    /**
+     * Loads the locale files from the jars file specific {@link Class}es was loaded from.
+     * <p>
+     * This method does not support using base names.
+     * <p>
+     * See {@link #addResourcesFromClass(Class, String)}.
+     */
+    void addResourcesFromClass(@NotNull List<Class<?>> classes);
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/ILocalizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/ILocalizer.java
@@ -1,0 +1,44 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.MissingResourceException;
+
+/**
+ * Represents a class that can localize strings.
+ *
+ * @author Pim
+ */
+public interface ILocalizer
+{
+    /**
+     * Retrieves a localized message.
+     *
+     * @param key    The key of the message.
+     * @param args   The arguments of the message, if any.
+     * @param locale The {@link Locale} to use.
+     * @return The localized message associated with the provided key.
+     */
+    @NotNull String getMessage(@NotNull String key, @NotNull Locale locale, @NotNull Object... args);
+
+    /**
+     * Retrieves a localized message using the default locale.
+     *
+     * @param key  The key of the message.
+     * @param args The arguments of the message, if any.
+     * @return The localized message associated with the provided key.
+     *
+     * @throws MissingResourceException When no mapping for the key can be found.
+     */
+    @NotNull String getMessage(@NotNull String key, @NotNull Object... args);
+
+    /**
+     * Gets a list of {@link Locale}s that are currently available.
+     *
+     * @return The list of available locales.
+     */
+    @SuppressWarnings("unused")
+    @NotNull List<Locale> getAvailableLocales();
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocaleFile.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocaleFile.java
@@ -1,0 +1,14 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Represents a translation file for a specific {@link Locale}.
+ *
+ * @param path   The path of the file.
+ * @param locale The {@link Locale} this file represents.
+ */
+record LocaleFile(@NotNull Path path, @NotNull String locale) {}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
@@ -142,6 +143,18 @@ final class LocalizationGenerator implements ILocalizationGenerator
     {
         for (final Class<?> clz : classes)
             addResourcesFromClass(clz, null);
+    }
+
+    /**
+     * Applies a set of patches to the existing output locale file.
+     *
+     * @param localeSuffix The suffix of the locale.
+     * @param patches      The patches to apply to the locale.
+     */
+    void applyPatches(@NotNull String localeSuffix, @NotNull Map<String, String> patches)
+    {
+        // FIXME: Implement method.
+        throw new UnsupportedOperationException("UNIMPLEMENTED!");
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -257,19 +257,4 @@ final class LocalizationGenerator implements ILocalizationGenerator
     {
         mergeWithExistingLocaleFile(outputFileSystem, Files.newInputStream(localeFile.path()), localeFile.locale());
     }
-
-    /**
-     * Retrieves the path of the output locale file.
-     * <p>
-     * The path is derived from {@link LocaleFile#path()} of the input locale file, {@link #outputDirectory}, and {@link
-     * #outputBaseName}.
-     *
-     * @param locale The locale used to derive the path of the output file.
-     * @return The path of the output file.
-     */
-    @SuppressWarnings("unused")
-    @NotNull Path getOutputLocaleFile(@NotNull String locale)
-    {
-        return outputDirectory.resolve(getOutputLocaleFileName(outputBaseName, locale));
-    }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -14,7 +14,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
 
@@ -26,8 +25,8 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
  *
  * @author Pim
  */
-@SuppressWarnings({"unused", "UnusedReturnValue"})
-public class LocalizationGenerator implements ILocalizationGenerator
+@SuppressWarnings("unused")
+class LocalizationGenerator implements ILocalizationGenerator
 {
     private final @NotNull Path outputDirectory;
 
@@ -41,7 +40,7 @@ public class LocalizationGenerator implements ILocalizationGenerator
      * @param outputDirectory The output directory to write all the combined localizations into.
      * @param outputBaseName  The base name of the properties files in the output directory.
      */
-    public LocalizationGenerator(@NotNull Path outputDirectory, @NotNull String outputBaseName)
+    LocalizationGenerator(@NotNull Path outputDirectory, @NotNull String outputBaseName)
     {
         this.outputDirectory = outputDirectory;
         this.outputBaseName = outputBaseName;
@@ -85,8 +84,7 @@ public class LocalizationGenerator implements ILocalizationGenerator
         {
             List<String> fileNames = Util.getLocaleFilesInJar(jarFile);
             if (baseName != null)
-                fileNames = fileNames.stream().filter(file -> file.startsWith(baseName))
-                                     .collect(Collectors.toList());
+                fileNames = fileNames.stream().filter(file -> file.startsWith(baseName)).toList();
 
             val localeFiles = getLocaleFiles(zipFileSystem, fileNames);
             for (val localeFile : localeFiles)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.bigdoors.localization;
 
+import lombok.Getter;
 import nl.pim16aap2.bigdoors.BigDoors;
 import nl.pim16aap2.bigdoors.util.Util;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +36,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
     /**
      * The output .bundle (zip) that holds all the localization files.
      */
+    @Getter
     private final Path outputFile;
     private final String outputBaseName;
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -109,7 +109,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
     {
         try (final FileSystem outputFileSystem = getOutputFileFileSystem())
         {
-            final Path existingLocaleFile = outputFileSystem.getPath(getOutputLocaleFileName(""));
+            final Path existingLocaleFile = outputFileSystem.getPath(getOutputLocaleFileName(outputBaseName, ""));
             ensureFileExists(existingLocaleFile);
             return LocalizationUtil.getKeySet(Files.newInputStream(existingLocaleFile));
         }
@@ -186,7 +186,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
                                      @NotNull String locale)
         throws IOException
     {
-        final Path existingLocaleFile = outputFileSystem.getPath(getOutputLocaleFileName(locale));
+        final Path existingLocaleFile = outputFileSystem.getPath(getOutputLocaleFileName(outputBaseName, locale));
         ensureFileExists(existingLocaleFile);
         ensureFileExists(outputFile);
         final List<String> existing = readFile(Files.newInputStream(existingLocaleFile));
@@ -216,17 +216,6 @@ final class LocalizationGenerator implements ILocalizationGenerator
     @SuppressWarnings("unused")
     @NotNull Path getOutputLocaleFile(@NotNull String locale)
     {
-        return outputDirectory.resolve(getOutputLocaleFileName(locale));
-    }
-
-    /**
-     * Retrieves the filename of the output locale file for a specific locale.
-     *
-     * @param locale The locale for which to find the output filename.
-     * @return The filename of the output locale file for the provided locale.
-     */
-    @NotNull String getOutputLocaleFileName(@NotNull String locale)
-    {
-        return String.format("%s%s.properties", outputBaseName, locale.length() == 0 ? "" : ("_" + locale));
+        return outputDirectory.resolve(getOutputLocaleFileName(outputBaseName, locale));
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -1,0 +1,98 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import lombok.Getter;
+import nl.pim16aap2.bigdoors.api.IConfigLoader;
+import nl.pim16aap2.bigdoors.api.restartable.IRestartableHolder;
+import nl.pim16aap2.bigdoors.api.restartable.Restartable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class LocalizationManager extends Restartable implements ILocalizationGenerator
+{
+    private final @NotNull Path baseDir;
+    private final @NotNull String baseName;
+    private final @NotNull IConfigLoader configLoader;
+    private final long buildID;
+    @Getter
+    private final @NotNull Localizer localizer;
+    private final @NotNull LocalizationGenerator baseGenerator;
+    private @Nullable LocalizationGenerator patchGenerator;
+
+    public LocalizationManager(@NotNull IRestartableHolder restartableHolder, @NotNull Path baseDir,
+                               @NotNull String baseName, @NotNull IConfigLoader configLoader, long buildID)
+    {
+        super(restartableHolder);
+        this.baseDir = baseDir;
+        this.baseName = baseName;
+        this.configLoader = configLoader;
+        this.buildID = buildID;
+        this.localizer = new Localizer(baseDir, baseName);
+        this.localizer.setDefaultLocale(configLoader.locale());
+        this.baseGenerator = new LocalizationGenerator(baseDir, baseName);
+    }
+
+    /**
+     * Runs a method for the currently installed generators while taking care of restarting the {@link #localizer} when
+     * needed.
+     */
+    private synchronized void runForGenerators(@NotNull Consumer<ILocalizationGenerator> method)
+    {
+        // If the localization system is not patched, shut down the localizer before running the method for the
+        // base generator so that the localizer sees the updated generated files. If there ARE patches, we don't need
+        // to shut down the localizer just yet, because the localizer doesn't use the base localization files.
+        if (this.patchGenerator == null)
+            localizer.shutdown();
+
+        method.accept(this.baseGenerator);
+
+        if (this.patchGenerator != null)
+        {
+            localizer.shutdown();
+            method.accept(this.patchGenerator);
+        }
+
+        localizer.restart();
+    }
+
+    @Override
+    public synchronized void addResources(@NotNull Path path, @Nullable String baseName)
+    {
+        runForGenerators(generator -> generator.addResources(path, baseName));
+    }
+
+    @Override
+    public synchronized void addResources(@NotNull List<Path> paths)
+    {
+        runForGenerators(generator -> generator.addResources(paths));
+    }
+
+    @Override
+    public synchronized void addResourcesFromClass(@NotNull Class<?> clz, @Nullable String baseName)
+    {
+        runForGenerators(generator -> generator.addResourcesFromClass(clz, baseName));
+    }
+
+    @Override
+    public synchronized void addResourcesFromClass(@NotNull List<Class<?>> classes)
+    {
+        runForGenerators(generator -> generator.addResourcesFromClass(classes));
+    }
+
+    @Override
+    public synchronized void restart()
+    {
+        shutdown();
+        // TODO: Implement
+        this.localizer.setDefaultLocale(configLoader.locale());
+    }
+
+    @Override
+    public synchronized void shutdown()
+    {
+        // TODO: Implement
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -30,9 +30,9 @@ public class LocalizationManager extends Restartable implements ILocalizationGen
         this.baseName = baseName;
         this.configLoader = configLoader;
         this.buildID = buildID;
-        this.localizer = new Localizer(baseDir, baseName);
-        this.localizer.setDefaultLocale(configLoader.locale());
-        this.baseGenerator = new LocalizationGenerator(baseDir, baseName);
+        localizer = new Localizer(baseDir, baseName);
+        localizer.setDefaultLocale(configLoader.locale());
+        baseGenerator = new LocalizationGenerator(baseDir, baseName);
     }
 
     /**
@@ -44,18 +44,18 @@ public class LocalizationManager extends Restartable implements ILocalizationGen
         // If the localization system is not patched, shut down the localizer before running the method for the
         // base generator so that the localizer sees the updated generated files. If there ARE patches, we don't need
         // to shut down the localizer just yet, because the localizer doesn't use the base localization files.
-        if (this.patchGenerator == null)
+        if (patchGenerator == null)
             localizer.shutdown();
 
-        method.accept(this.baseGenerator);
+        method.accept(baseGenerator);
 
-        if (this.patchGenerator != null)
+        if (patchGenerator != null)
         {
             localizer.shutdown();
-            method.accept(this.patchGenerator);
+            method.accept(patchGenerator);
         }
 
-        localizer.restart();
+        localizer.init();
     }
 
     @Override
@@ -87,7 +87,7 @@ public class LocalizationManager extends Restartable implements ILocalizationGen
     {
         shutdown();
         // TODO: Implement
-        this.localizer.setDefaultLocale(configLoader.locale());
+        localizer.setDefaultLocale(configLoader.locale());
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -6,6 +6,7 @@ import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -22,7 +23,7 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     private final @NotNull String baseName;
     private final @NotNull IConfigLoader configLoader;
     private final long buildID;
-    private final @NotNull Localizer localizer;
+    private @NotNull Localizer localizer;
     private final @NotNull LocalizationGenerator baseGenerator;
     private @Nullable LocalizationGenerator patchGenerator;
 
@@ -63,7 +64,23 @@ public final class LocalizationManager extends Restartable implements ILocalizat
             rootKeys = patchGenerator.getOutputRootKeys();
         }
 
+        try
+        {
+            applyPatches(rootKeys);
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+
         localizer.init();
+    }
+
+    synchronized void applyPatches(@NotNull Set<String> rootKeys)
+        throws IOException
+    {
+        final LocalizationPatcher localizationPatcher = new LocalizationPatcher(baseDir, baseName);
+        localizationPatcher.updatePatchKeys(rootKeys);
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -26,7 +26,7 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     private final @NotNull String baseName;
     private final @NotNull IConfigLoader configLoader;
     private final long buildID;
-    private @NotNull Localizer localizer;
+    private final @NotNull Localizer localizer;
     private final @NotNull LocalizationGenerator baseGenerator;
     private @Nullable LocalizationGenerator patchGenerator;
 
@@ -93,7 +93,7 @@ public final class LocalizationManager extends Restartable implements ILocalizat
             if (patchGenerator == null)
             {
                 patchGenerator = new LocalizationGenerator(baseDir, baseName + "_patched");
-                // TODO: Point Localizer to new files.
+                localizer.updateBundleLocation(baseDir, baseName + "_patched");
             }
 
             // Satisfy NullAway, as it doesn't realize that targetGenerator cannot be null here.
@@ -144,7 +144,6 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     public synchronized void shutdown()
     {
         localizer.shutdown();
-        // TODO: Implement
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -25,19 +25,17 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     private final @NotNull Path baseDir;
     private final @NotNull String baseName;
     private final @NotNull IConfigLoader configLoader;
-    private final long buildID;
     private final @NotNull Localizer localizer;
     private final @NotNull LocalizationGenerator baseGenerator;
     private @Nullable LocalizationGenerator patchGenerator;
 
     public LocalizationManager(@NotNull IRestartableHolder restartableHolder, @NotNull Path baseDir,
-                               @NotNull String baseName, @NotNull IConfigLoader configLoader, long buildID)
+                               @NotNull String baseName, @NotNull IConfigLoader configLoader)
     {
         super(restartableHolder);
         this.baseDir = baseDir;
         this.baseName = baseName;
         this.configLoader = configLoader;
-        this.buildID = buildID;
         localizer = new Localizer(baseDir, baseName);
         localizer.setDefaultLocale(configLoader.locale());
         baseGenerator = new LocalizationGenerator(baseDir, baseName);
@@ -81,8 +79,9 @@ public final class LocalizationManager extends Restartable implements ILocalizat
         {
             final LocalizationPatcher localizationPatcher = new LocalizationPatcher(baseDir, baseName);
             final Set<String> rootKeys = (patchGenerator == null ? baseGenerator : patchGenerator).getOutputRootKeys();
-            final List<LocaleFile> patchFiles = localizationPatcher.updatePatchKeys(rootKeys);
+            localizationPatcher.updatePatchKeys(rootKeys);
 
+            final List<LocaleFile> patchFiles = localizationPatcher.getPatchFiles();
             final Map<LocaleFile, Map<String, String>> patches = new HashMap<>(patchFiles.size());
             patchFiles.forEach(localeFile -> patches.put(localeFile, localizationPatcher.getPatches(localeFile)));
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -1,6 +1,5 @@
 package nl.pim16aap2.bigdoors.localization;
 
-import lombok.Getter;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.restartable.IRestartableHolder;
 import nl.pim16aap2.bigdoors.api.restartable.Restartable;
@@ -12,13 +11,17 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+/**
+ * Represents a manager for the localization system.
+ *
+ * @author Pim
+ */
 public final class LocalizationManager extends Restartable implements ILocalizationGenerator
 {
     private final @NotNull Path baseDir;
     private final @NotNull String baseName;
     private final @NotNull IConfigLoader configLoader;
     private final long buildID;
-    @Getter
     private final @NotNull Localizer localizer;
     private final @NotNull LocalizationGenerator baseGenerator;
     private @Nullable LocalizationGenerator patchGenerator;
@@ -99,5 +102,10 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     public synchronized void shutdown()
     {
         // TODO: Implement
+    }
+
+    public @NotNull ILocalizer getLocalizer()
+    {
+        return localizer;
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
@@ -1,6 +1,5 @@
 package nl.pim16aap2.bigdoors.localization;
 
-import lombok.Getter;
 import nl.pim16aap2.bigdoors.BigDoors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -10,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -28,8 +26,6 @@ final class LocalizationPatcher
 {
     private final String baseName;
     private final Path directory;
-    @Getter
-    private @NotNull List<LocaleFile> patchFiles = Collections.emptyList();
 
     LocalizationPatcher(@NotNull Path directory, @NotNull String baseName)
         throws IOException
@@ -45,11 +41,13 @@ final class LocalizationPatcher
      * Any root keys not already present in the patch file(s) will be appended to the file without a value.
      *
      * @param rootKeys The localization keys in the root locale file.
+     * @return The list of patch files that were found.
      */
-    void updatePatchKeys(@NotNull Collection<String> rootKeys)
+    @NotNull List<LocaleFile> updatePatchKeys(@NotNull Collection<String> rootKeys)
     {
-        patchFiles = getLocaleFilesInDirectory(directory, baseName);
+        final List<LocaleFile> patchFiles = getLocaleFilesInDirectory(directory, baseName);
         patchFiles.forEach(patchFile -> updatePatchKeys(rootKeys, patchFile));
+        return patchFiles;
     }
 
     /**
@@ -96,14 +94,13 @@ final class LocalizationPatcher
      * <p>
      * A patch is defined in this context as a key/value pair with a non-empty value.
      *
-     * @param localeSuffix The suffix of the locale to get the patches for.
+     * @param localeFile The locale file to read the patches from.
      * @return A map of the patches. The keys are the localization keys and the values the full line (i.e. "key=value").
      */
-    @NotNull Map<String, String> getPatches(@NotNull String localeSuffix)
+    @NotNull Map<String, String> getPatches(@NotNull LocaleFile localeFile)
     {
-        final Path localeFile = directory.resolve(getOutputLocaleFileName(baseName, localeSuffix));
         final Map<String, String> ret = new LinkedHashMap<>();
-        readFile(localeFile, line ->
+        readFile(localeFile.path(), line ->
         {
             final @Nullable String key = getKeyFromLine(line);
             if (isValidPatch(key, line))

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.bigdoors.localization;
 import lombok.Getter;
 import nl.pim16aap2.bigdoors.BigDoors;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +101,28 @@ final class LocalizationPatcher
      */
     @NotNull Map<String, String> getPatches(@NotNull String localeSuffix)
     {
-        // FIXME: Implement method.
-        throw new UnsupportedOperationException("UNIMPLEMENTED!");
+        final Path localeFile = directory.resolve(getOutputLocaleFileName(baseName, localeSuffix));
+        final Map<String, String> ret = new LinkedHashMap<>();
+        readFile(localeFile, line ->
+        {
+            final @Nullable String key = getKeyFromLine(line);
+            if (isValidPatch(key, line))
+                ret.put(key, line);
+        });
+        return ret;
+    }
+
+    /**
+     * Tests if a line is a valid patch.
+     *
+     * @param key  The key of the line.
+     * @param line The line itself.
+     * @return True if the patch is valid (i.e. not empty).
+     */
+    static boolean isValidPatch(@Nullable String key, @NotNull String line)
+    {
+        if (key == null)
+            return false;
+        return !(key + "=").equals(line);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
@@ -1,0 +1,105 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import lombok.Getter;
+import nl.pim16aap2.bigdoors.BigDoors;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
+
+/**
+ * Represents a class that can be used to apply user-defined localization patches.
+ *
+ * @author Pim
+ */
+final class LocalizationPatcher
+{
+    private final String baseName;
+    private final Path directory;
+    @Getter
+    private @NotNull List<LocaleFile> patchFiles = Collections.emptyList();
+
+    LocalizationPatcher(@NotNull Path directory, @NotNull String baseName)
+        throws IOException
+    {
+        this.directory = directory;
+        this.baseName = baseName;
+        ensureFileExists(directory.resolve(this.baseName + ".properties"));
+    }
+
+    /**
+     * Updates the localization keys in the patch file(s).
+     * <p>
+     * Any root keys not already present in the patch file(s) will be appended to the file without a value.
+     *
+     * @param rootKeys The localization keys in the root locale file.
+     */
+    void updatePatchKeys(@NotNull Collection<String> rootKeys)
+    {
+        patchFiles = getLocaleFilesInDirectory(directory, baseName);
+        patchFiles.forEach(patchFile -> updatePatchKeys(rootKeys, patchFile));
+    }
+
+    /**
+     * Updates the localization keys in the patch file.
+     * <p>
+     * Any root keys not already present in the patch file will be appended to the file without a value.
+     *
+     * @param rootKeys   The localization keys in the root locale file.
+     * @param localeFile The locale file to append any missing localization keys to.
+     */
+    void updatePatchKeys(@NotNull Collection<String> rootKeys, @NotNull LocaleFile localeFile)
+    {
+        final Set<String> patchKeys = getKeySet(localeFile.path());
+        final Set<String> appendableKeys = new LinkedHashSet<>(rootKeys);
+        appendableKeys.removeAll(patchKeys);
+        appendKeys(localeFile, appendableKeys);
+    }
+
+    /**
+     * Appends localization keys to a locale file.
+     *
+     * @param localeFile     The locale file to append the keys to.
+     * @param appendableKeys The localization keys to append to the locale file.
+     */
+    void appendKeys(@NotNull LocaleFile localeFile, @NotNull Set<String> appendableKeys)
+    {
+        if (appendableKeys.isEmpty())
+            return;
+
+        final StringBuilder sb = new StringBuilder();
+        appendableKeys.forEach(key -> sb.append(key).append("=\n"));
+        try
+        {
+            Files.write(localeFile.path(), sb.toString().getBytes(), StandardOpenOption.APPEND);
+        }
+        catch (IOException e)
+        {
+            BigDoors.get().getPLogger().logThrowable(e, "Failed to append new keys to file: " + localeFile.path());
+        }
+    }
+
+    /**
+     * Gets the patches for a given locale that are specified in the patch file.
+     * <p>
+     * A patch is defined in this context as a key/value pair with a non-empty value.
+     *
+     * @param localeSuffix The suffix of the locale to get the patches for.
+     * @return A map of the patches. The keys are the localization keys and the values the full line (i.e. "key=value").
+     */
+    @NotNull Map<String, String> getPatches(@NotNull String localeSuffix)
+    {
+        // FIXME: Implement method.
+        throw new UnsupportedOperationException("UNIMPLEMENTED!");
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
@@ -25,21 +25,14 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
  */
 final class LocalizationPatcher
 {
-    private final String baseName;
-    private final Path directory;
-    private final Path patchedBundle;
     @Getter
     private final List<LocaleFile> patchFiles;
 
     LocalizationPatcher(@NotNull Path directory, @NotNull String baseName)
         throws IOException
     {
-        this.directory = directory;
-        this.baseName = baseName;
-        patchedBundle = directory.resolve(baseName + "_patched.bundle");
-
         // Ensure the base patch file exists.
-        ensureFileExists(directory.resolve(this.baseName + ".properties"));
+        ensureFileExists(directory.resolve(baseName + ".properties"));
         patchFiles = getLocaleFilesInDirectory(directory, baseName);
     }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcher.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.bigdoors.localization;
 
+import lombok.Getter;
 import nl.pim16aap2.bigdoors.BigDoors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,13 +27,20 @@ final class LocalizationPatcher
 {
     private final String baseName;
     private final Path directory;
+    private final Path patchedBundle;
+    @Getter
+    private final List<LocaleFile> patchFiles;
 
     LocalizationPatcher(@NotNull Path directory, @NotNull String baseName)
         throws IOException
     {
         this.directory = directory;
         this.baseName = baseName;
+        patchedBundle = directory.resolve(baseName + "_patched.bundle");
+
+        // Ensure the base patch file exists.
         ensureFileExists(directory.resolve(this.baseName + ".properties"));
+        patchFiles = getLocaleFilesInDirectory(directory, baseName);
     }
 
     /**
@@ -41,13 +49,10 @@ final class LocalizationPatcher
      * Any root keys not already present in the patch file(s) will be appended to the file without a value.
      *
      * @param rootKeys The localization keys in the root locale file.
-     * @return The list of patch files that were found.
      */
-    @NotNull List<LocaleFile> updatePatchKeys(@NotNull Collection<String> rootKeys)
+    void updatePatchKeys(@NotNull Collection<String> rootKeys)
     {
-        final List<LocaleFile> patchFiles = getLocaleFilesInDirectory(directory, baseName);
         patchFiles.forEach(patchFile -> updatePatchKeys(rootKeys, patchFile));
-        return patchFiles;
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -476,12 +476,4 @@ public final class LocalizationUtil
             return new Locale(parts[0], parts[1]);
         return new Locale(parts[0], parts[1], parts[2]);
     }
-
-    /**
-     * Represents a translation file for a specific {@link Locale}.
-     *
-     * @param path   The path of the file.
-     * @param locale The {@link Locale} this file represents.
-     */
-    record LocaleFile(@NotNull Path path, @NotNull String locale) {}
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -45,18 +45,20 @@ public final class LocalizationUtil
      * If the file does not already exist, it will be created.
      *
      * @param file The file whose existence to ensure.
+     * @return The path to the file.
+     *
      * @throws IOException When the file could not be created.
      */
-    static void ensureFileExists(@NotNull Path file)
+    static Path ensureFileExists(@NotNull Path file)
         throws IOException
     {
         if (Files.isRegularFile(file))
-            return;
+            return file;
 
         final Path parent = file.getParent();
         if (parent != null)
             Files.createDirectories(parent);
-        Files.createFile(file);
+        return Files.createFile(file);
     }
 
     /**
@@ -129,12 +131,33 @@ public final class LocalizationUtil
     }
 
     /**
+     * Gets a set containing all the keys in a file.
+     *
+     * @param path The path to a file.
+     * @return A set with all the keys used in the file.
+     */
+    static Set<String> getKeySet(@NotNull Path path)
+    {
+        if (!Files.isRegularFile(path))
+            return Collections.emptySet();
+        try (final InputStream inputStream = Files.newInputStream(path))
+        {
+            return getKeySet(inputStream);
+        }
+        catch (IOException e)
+        {
+            BigDoors.get().getPLogger().logThrowable(e, "Failed to get keys from file: " + path);
+            return Collections.emptySet();
+        }
+    }
+
+    /**
      * Gets a set containing all the keys in a list of strings.
      *
      * @param lines The lines containing "key=value" mappings.
      * @return A set with all the keys used in the lines.
      */
-    static Set<@Nullable String> getKeySet(@NotNull List<String> lines)
+    static Set<String> getKeySet(@NotNull List<String> lines)
     {
         final Set<String> ret = new LinkedHashSet<>(lines.size());
         for (final String line : lines)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -247,13 +247,6 @@ public final class LocalizationUtil
         }
     }
 
-    static @NotNull List<String> readFile(@NotNull Path path)
-    {
-        final List<String> ret = new ArrayList<>();
-        readFile(path, ret::add);
-        return ret;
-    }
-
     /**
      * Retrieves all the {@link LocaleFile}s in a directory.
      *

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -225,6 +225,28 @@ public final class LocalizationUtil
     }
 
     /**
+     * Reads all the lines from a file and stores each line in a list.
+     *
+     * @param path The path to the file to read the data from.
+     * @return A list of Strings where every string represents a single line in the provided file.
+     */
+    static @NotNull List<String> readFile(@NotNull Path path)
+    {
+        if (!Files.isRegularFile(path))
+            return Collections.emptyList();
+        try (final InputStream inputStream = Files.newInputStream(path))
+        {
+            return readFile(inputStream);
+        }
+        catch (IOException e)
+        {
+            BigDoors.get().getPLogger().logThrowable(e, "Failed to read file: " + path);
+            return Collections.emptyList();
+        }
+
+    }
+
+    /**
      * Retrieves all the {@link LocaleFile}s in a directory.
      *
      * @param directory The directory to search in.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -15,6 +15,7 @@ import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.ProviderNotFoundException;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -385,7 +386,7 @@ public final class LocalizationUtil
      * @throws FileSystemAlreadyExistsException When a FileSystem already exists for the provided file.
      */
     static @NotNull FileSystem createNewFileSystem(@NotNull Path zipFile)
-        throws IOException, URISyntaxException
+        throws IOException, URISyntaxException, ProviderNotFoundException
     {
         return FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
     }
@@ -449,7 +450,7 @@ public final class LocalizationUtil
             return LocalizationUtil.getLocaleFilesInDirectory(fs.getPath("."), baseName).stream()
                                    .map(localeFile -> getLocale(localeFile.locale())).toList();
         }
-        catch (IOException | URISyntaxException e)
+        catch (IOException | URISyntaxException | ProviderNotFoundException e)
         {
             BigDoors.get().getPLogger().logThrowable(e, "Failed to find locales in file: " + zipFile);
             return Collections.emptyList();

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -192,7 +192,7 @@ public final class LocalizationUtil
      * @param inputStream The input stream to read the data from.
      * @param fun         The function to apply for each line retrieved from the input stream.
      */
-    static void readFile(@NotNull InputStream inputStream, Consumer<String> fun)
+    static void readFile(@NotNull InputStream inputStream, @NotNull Consumer<String> fun)
     {
         try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream)))
         {
@@ -228,22 +228,29 @@ public final class LocalizationUtil
      * Reads all the lines from a file and stores each line in a list.
      *
      * @param path The path to the file to read the data from.
+     * @param fun  The function to apply for each line retrieved from the input stream.
      * @return A list of Strings where every string represents a single line in the provided file.
      */
-    static @NotNull List<String> readFile(@NotNull Path path)
+    static void readFile(@NotNull Path path, @NotNull Consumer<String> fun)
     {
         if (!Files.isRegularFile(path))
-            return Collections.emptyList();
+            return;
+
         try (final InputStream inputStream = Files.newInputStream(path))
         {
-            return readFile(inputStream);
+            readFile(inputStream, fun);
         }
         catch (IOException e)
         {
             BigDoors.get().getPLogger().logThrowable(e, "Failed to read file: " + path);
-            return Collections.emptyList();
         }
+    }
 
+    static @NotNull List<String> readFile(@NotNull Path path)
+    {
+        final List<String> ret = new ArrayList<>();
+        readFile(path, ret::add);
+        return ret;
     }
 
     /**
@@ -381,6 +388,17 @@ public final class LocalizationUtil
         throws IOException, URISyntaxException
     {
         return FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
+    }
+
+    /**
+     * Retrieves the filename of the output locale file for a specific locale.
+     *
+     * @param locale The locale for which to find the output filename.
+     * @return The filename of the output locale file for the provided locale.
+     */
+    static @NotNull String getOutputLocaleFileName(@NotNull String outputBaseName, @NotNull String locale)
+    {
+        return String.format("%s%s.properties", outputBaseName, locale.length() == 0 ? "" : ("_" + locale));
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -1,6 +1,5 @@
 package nl.pim16aap2.bigdoors.localization;
 
-import lombok.val;
 import nl.pim16aap2.bigdoors.BigDoors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,7 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipOutputStream;
 
 /**
@@ -52,7 +51,7 @@ public class LocalizationUtil
     {
         if (Files.isRegularFile(file))
             return;
-        val parent = file.getParent();
+        final Path parent = file.getParent();
         if (parent != null)
             Files.createDirectories(parent);
         Files.createFile(file);
@@ -71,7 +70,7 @@ public class LocalizationUtil
         if (append.isEmpty())
             return;
 
-        val sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder();
         append.forEach(line -> sb.append(line).append("\n"));
         try
         {
@@ -98,12 +97,12 @@ public class LocalizationUtil
         if (existing.isEmpty())
             return newLines;
 
-        val keys = getKeySet(existing);
-        val merged = new ArrayList<String>(newLines.size());
+        final Set<@Nullable String> keys = getKeySet(existing);
+        final ArrayList<String> merged = new ArrayList<>(newLines.size());
 
-        for (val line : newLines)
+        for (final String line : newLines)
         {
-            val key = getKeyFromLine(line);
+            final @Nullable String key = getKeyFromLine(line);
             if (key == null || keys.contains(key))
                 continue;
             merged.add(line);
@@ -119,12 +118,12 @@ public class LocalizationUtil
      * @param lines The lines containing "key=value" mappings.
      * @return A set with all the keys used in the lines.
      */
-    static @NotNull Set<String> getKeySet(@NotNull List<String> lines)
+    static Set<@Nullable String> getKeySet(@NotNull List<String> lines)
     {
         final Set<String> ret = new LinkedHashSet<>(lines.size());
-        for (val line : lines)
+        for (final String line : lines)
         {
-            val key = getKeyFromLine(line);
+            final @Nullable String key = getKeyFromLine(line);
             if (key != null)
                 ret.add(key);
         }
@@ -157,7 +156,7 @@ public class LocalizationUtil
     {
         final ArrayList<String> tmp = new ArrayList<>();
 
-        try (val bufferedReader = new BufferedReader(new InputStreamReader(inputStream)))
+        try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream)))
         {
             for (String line; (line = bufferedReader.readLine()) != null; )
             {
@@ -185,10 +184,9 @@ public class LocalizationUtil
      */
     static @NotNull List<LocaleFile> getLocaleFilesInDirectory(@NotNull Path directory, @Nullable String baseName)
     {
-        try (val stream = Files.list(directory))
+        try (final Stream<Path> stream = Files.list(directory))
         {
-            return getLocaleFiles(baseName,
-                                  stream.filter(file -> !Files.isDirectory(file)).collect(Collectors.toList()));
+            return getLocaleFiles(baseName, stream.filter(file -> !Files.isDirectory(file)).toList());
         }
         catch (IOException e)
         {
@@ -207,9 +205,9 @@ public class LocalizationUtil
     static @NotNull List<LocaleFile> getLocaleFiles(@Nullable String baseName, @NotNull List<Path> files)
     {
         final @NotNull ArrayList<LocaleFile> ret = new ArrayList<>(files.size());
-        for (val file : files)
+        for (final Path file : files)
         {
-            @Nullable val locale = parseLocaleFile(baseName, file.getFileName().toString());
+            final @Nullable String locale = parseLocaleFile(baseName, file.getFileName().toString());
             if (locale != null)
                 ret.add(new LocaleFile(file, locale));
         }
@@ -240,9 +238,9 @@ public class LocalizationUtil
     static @NotNull List<LocaleFile> getLocaleFiles(@NotNull FileSystem fileSystem, @NotNull List<String> resources)
     {
         final ArrayList<LocaleFile> ret = new ArrayList<>(resources.size());
-        for (val resource : resources)
+        for (final String resource : resources)
         {
-            @Nullable val locale = parseLocaleFile(resource);
+            final @Nullable String locale = parseLocaleFile(resource);
             if (locale != null)
                 ret.add(new LocaleFile(fileSystem.getPath(resource), locale));
         }
@@ -293,7 +291,7 @@ public class LocalizationUtil
     {
         if (!fileName.endsWith(".properties"))
             return null;
-        val parts = fileName.replace(".properties", "").split("_", 2);
+        final String[] parts = fileName.replace(".properties", "").split("_", 2);
         return parts.length == 1 ? "" : parts[1];
     }
 
@@ -322,7 +320,7 @@ public class LocalizationUtil
         if (Files.exists(zipFile))
             return;
 
-        val parent = zipFile.getParent();
+        final Path parent = zipFile.getParent();
         if (parent != null)
         {
             try
@@ -339,7 +337,7 @@ public class LocalizationUtil
         // Just opening the ZipOutputStream and then letting it close
         // on its own is enough to create a new zip file.
         //noinspection EmptyTryBlock
-        try (val ignored = new ZipOutputStream(Files.newOutputStream(zipFile)))
+        try (final ZipOutputStream ignored = new ZipOutputStream(Files.newOutputStream(zipFile)))
         {
             // ignored
         }
@@ -357,7 +355,7 @@ public class LocalizationUtil
      */
     static @NotNull List<Locale> getLocalesInZip(@NotNull Path zipFile, @NotNull String baseName)
     {
-        try (val fs = createNewFileSystem(zipFile))
+        try (final FileSystem fs = createNewFileSystem(zipFile))
         {
             return LocalizationUtil.getLocaleFilesInDirectory(fs.getPath("."), baseName).stream()
                                    .map(localeFile -> getLocale(localeFile.locale())).toList();
@@ -379,7 +377,7 @@ public class LocalizationUtil
      */
     public static @NotNull Locale getLocale(@NotNull String localeStr)
     {
-        val parts = localeStr.split("_", 3);
+        final String[] parts = localeStr.split("_", 3);
         if (parts[0].isBlank())
             return Locale.ROOT;
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -66,7 +66,24 @@ final class Localizer implements ILocalizer
         this(directory, baseName, Locale.ROOT);
     }
 
-    @Override public @NotNull String getMessage(@NotNull String key, @NotNull Locale locale, @NotNull Object... args)
+    /**
+     * Updates the location of the localization bundle being used.
+     * <p>
+     * Don't forget to use {@link #reInit()} to apply the changes.
+     *
+     * @param directory The directory the translation file(s) exist in.
+     * @param baseName  The base name of the localization files. For example, when you have a file
+     *                  "Translations_en_US.properties", the base name would be "Translations".
+     */
+    void updateBundleLocation(@NotNull Path directory, @NotNull String baseName)
+    {
+        this.baseName = baseName;
+        this.directory = directory;
+        bundleName = baseName + ".bundle";
+    }
+
+    @Override
+    public @NotNull String getMessage(@NotNull String key, @NotNull Locale locale, @NotNull Object... args)
     {
         if (classLoader == null)
         {

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -1,13 +1,13 @@
 package nl.pim16aap2.bigdoors.localization;
 
 import lombok.Setter;
-import lombok.val;
 import nl.pim16aap2.bigdoors.BigDoors;
 import nl.pim16aap2.bigdoors.annotations.Initializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -85,7 +85,7 @@ public class Localizer
 
         try
         {
-            val msg = ResourceBundle.getBundle(baseName, locale, classLoader).getString(key);
+            final String msg = ResourceBundle.getBundle(baseName, locale, classLoader).getString(key);
             return args.length == 0 ? msg : MessageFormat.format(msg, args);
         }
         catch (MissingResourceException e)
@@ -134,7 +134,7 @@ public class Localizer
         if (classLoader != null)
             throw new IllegalStateException("ClassLoader is already initialized!");
 
-        val bundlePath = directory.resolve(bundleName);
+        final Path bundlePath = directory.resolve(bundleName);
         ensureZipFileExists(bundlePath);
         try
         {
@@ -153,13 +153,13 @@ public class Localizer
         throws IOException
     {
         final URL[] urls = {bundlePath.toUri().toURL()};
-        val ucl = new URLClassLoader(urls);
+        final URLClassLoader ucl = new URLClassLoader(urls);
         // Get the base file (which we know exists) as stream. This is a hack to ensure
         // that the files accessed by the ResourceBundle are current.
         // When skipping this step, the ResourceBundle will not see any changes
         // made to the files since the last time the UCL was recreated.
         //noinspection EmptyTryBlock
-        try (val ignored = ucl.getResourceAsStream(baseName + ".properties"))
+        try (final InputStream ignored = ucl.getResourceAsStream(baseName + ".properties"))
         {
             // ignored
         }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -25,7 +25,7 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.ensureZipFileE
  *
  * @author Pim
  */
-public final class Localizer
+final class Localizer implements ILocalizer
 {
     static final String KEY_NOT_FOUND_MESSAGE = "Failed to localize message: ";
 
@@ -66,15 +66,7 @@ public final class Localizer
         this(directory, baseName, Locale.ROOT);
     }
 
-    /**
-     * Retrieves a localized message.
-     *
-     * @param key    The key of the message.
-     * @param args   The arguments of the message, if any.
-     * @param locale The {@link Locale} to use.
-     * @return The localized message associated with the provided key.
-     */
-    public @NotNull String getMessage(@NotNull String key, @NotNull Locale locale, @NotNull Object... args)
+    @Override public @NotNull String getMessage(@NotNull String key, @NotNull Locale locale, @NotNull Object... args)
     {
         if (classLoader == null)
         {
@@ -96,26 +88,12 @@ public final class Localizer
         }
     }
 
-    /**
-     * Retrieves a localized message using {@link #defaultLocale}.
-     *
-     * @param key  The key of the message.
-     * @param args The arguments of the message, if any.
-     * @return The localized message associated with the provided key.
-     *
-     * @throws MissingResourceException When no mapping for the key can be found.
-     */
-    public @NotNull String getMessage(@NotNull String key, @NotNull Object... args)
+    @Override public @NotNull String getMessage(@NotNull String key, @NotNull Object... args)
     {
         return getMessage(key, defaultLocale, args);
     }
 
-    /**
-     * Gets a list of {@link Locale}s that are currently available.
-     *
-     * @return The list of available locales.
-     */
-    @SuppressWarnings("unused")
+    @Override @SuppressWarnings("unused")
     public @NotNull List<Locale> getAvailableLocales()
     {
         return localeList;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -25,7 +25,7 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.ensureZipFileE
  *
  * @author Pim
  */
-public class Localizer
+public final class Localizer
 {
     static final String KEY_NOT_FOUND_MESSAGE = "Failed to localize message: ";
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -29,9 +29,9 @@ final class Localizer implements ILocalizer
 {
     static final String KEY_NOT_FOUND_MESSAGE = "Failed to localize message: ";
 
-    private final @NotNull Path directory;
-    private final @NotNull String baseName;
-    private final @NotNull String bundleName;
+    private @NotNull Path directory;
+    private @NotNull String baseName;
+    private @NotNull String bundleName;
 
     /**
      * The default {@link Locale} to use when no locale is specified when requesting a translation. Defaults to {@link
@@ -88,7 +88,8 @@ final class Localizer implements ILocalizer
         }
     }
 
-    @Override public @NotNull String getMessage(@NotNull String key, @NotNull Object... args)
+    @Override
+    public @NotNull String getMessage(@NotNull String key, @NotNull Object... args)
     {
         return getMessage(key, defaultLocale, args);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -4,8 +4,7 @@ import lombok.Setter;
 import lombok.val;
 import nl.pim16aap2.bigdoors.BigDoors;
 import nl.pim16aap2.bigdoors.annotations.Initializer;
-import nl.pim16aap2.bigdoors.api.restartable.IRestartableHolder;
-import nl.pim16aap2.bigdoors.api.restartable.Restartable;
+import nl.pim16aap2.bigdoors.api.restartable.IRestartable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,7 +26,7 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.ensureZipFileE
  *
  * @author Pim
  */
-public class Localizer extends Restartable
+public class Localizer implements IRestartable
 {
     static final String KEY_NOT_FOUND_MESSAGE = "Failed to localize message: ";
 
@@ -45,17 +44,14 @@ public class Localizer extends Restartable
     private List<Locale> localeList;
 
     /**
-     * @param restartableHolder The {@link IRestartableHolder} to register this class with.
-     * @param directory         The directory the translation file(s) exist in.
-     * @param baseName          The base name of the localization files. For example, when you have a file
-     *                          "Translations_en_US.properties", the base name would be "Translations".
-     * @param defaultLocale     The default {@link Locale} to use when no locale is specified when requesting a
-     *                          translation. Defaults to {@link Locale#ROOT}.
+     * @param directory     The directory the translation file(s) exist in.
+     * @param baseName      The base name of the localization files. For example, when you have a file
+     *                      "Translations_en_US.properties", the base name would be "Translations".
+     * @param defaultLocale The default {@link Locale} to use when no locale is specified when requesting a translation.
+     *                      Defaults to {@link Locale#ROOT}.
      */
-    public Localizer(@NotNull IRestartableHolder restartableHolder, @NotNull Path directory, @NotNull String baseName,
-                     @NotNull Locale defaultLocale)
+    public Localizer(@NotNull Path directory, @NotNull String baseName, @NotNull Locale defaultLocale)
     {
-        super(restartableHolder);
         this.baseName = baseName;
         this.directory = directory;
         this.defaultLocale = defaultLocale;
@@ -63,25 +59,12 @@ public class Localizer extends Restartable
         init();
     }
 
-    public Localizer(@NotNull IRestartableHolder restartableHolder, @NotNull Path directory, @NotNull String baseName)
-    {
-        this(restartableHolder, directory, baseName, Locale.ROOT);
-    }
-
     /**
-     * See {@link #Localizer(IRestartableHolder, Path, String, Locale)}.
-     */
-    public Localizer(@NotNull Path directory, @NotNull String baseName, @NotNull Locale defaultLocale)
-    {
-        this(BigDoors.get(), directory, baseName, defaultLocale);
-    }
-
-    /**
-     * See {@link #Localizer(IRestartableHolder, Path, String, Locale)}.
+     * See {@link #Localizer(Path, String, Locale)}.
      */
     public Localizer(@NotNull Path directory, @NotNull String baseName)
     {
-        this(BigDoors.get(), directory, baseName);
+        this(directory, baseName, Locale.ROOT);
     }
 
     /**

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/UnitTestUtil.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/UnitTestUtil.java
@@ -4,7 +4,7 @@ import lombok.val;
 import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPLocation;
 import nl.pim16aap2.bigdoors.api.IPWorld;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.logging.BasicPLogger;
 import nl.pim16aap2.bigdoors.util.vector.Vector2Di;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
@@ -38,9 +38,9 @@ public class UnitTestUtil
         return platform;
     }
 
-    public static @NotNull Localizer initLocalizer()
+    public static @NotNull ILocalizer initLocalizer()
     {
-        val localizer = Mockito.mock(Localizer.class);
+        val localizer = Mockito.mock(ILocalizer.class);
         Mockito.when(localizer.getMessage(Mockito.anyString()))
                .thenAnswer(invocation -> invocation.getArgument(0, String.class));
         Mockito.when(localizer.getMessage(Mockito.anyString(), Mockito.any()))

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/AddOwnerTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/AddOwnerTest.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.UnitTestUtil;
 import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.doors.AbstractDoor;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.util.DoorRetriever;
@@ -137,7 +137,7 @@ class AddOwnerTest
     @SneakyThrows
     void testDelayedInput()
     {
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
         val databaseManager = mockDatabaseManager();
 
         Mockito.when(door.getDoorOwner(commandSender)).thenReturn(Optional.of(doorOwner0));
@@ -158,7 +158,7 @@ class AddOwnerTest
     void testStaticRunners()
     {
         val databaseManager = mockDatabaseManager();
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
 
         Mockito.when(door.getDoorOwner(commandSender)).thenReturn(Optional.of(doorOwner0));
         Mockito.when(door.getDoorOwner(target)).thenReturn(Optional.of(doorOwner1));

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/RemoveOwnerTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/RemoveOwnerTest.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.UnitTestUtil;
 import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.doors.AbstractDoor;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.util.DoorRetriever;
@@ -123,7 +123,7 @@ class RemoveOwnerTest
     void testDelayedInput()
     {
         Mockito.when(doorRetriever.getDoor()).thenReturn(CompletableFuture.completedFuture(Optional.of(door)));
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
         val databaseManager = mockDatabaseManager();
 
         Mockito.when(door.getDoorOwner(commandSender)).thenReturn(Optional.of(doorOwner0));
@@ -145,7 +145,7 @@ class RemoveOwnerTest
     {
         Mockito.when(doorRetriever.getDoor()).thenReturn(CompletableFuture.completedFuture(Optional.of(door)));
         val databaseManager = mockDatabaseManager();
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
 
         Mockito.when(door.getDoorOwner(commandSender)).thenReturn(Optional.of(doorOwner0));
         Mockito.when(door.getDoorOwner(target)).thenReturn(Optional.of(doorOwner1));

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetAutoCloseTimeTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetAutoCloseTimeTest.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.doors.AbstractDoor;
 import nl.pim16aap2.bigdoors.doors.doorArchetypes.ITimerToggleable;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.util.DoorRetriever;
 import org.junit.jupiter.api.Assertions;
@@ -86,7 +86,7 @@ class SetAutoCloseTimeTest
     void testDelayedInput()
     {
         final int autoCloseValue = 42;
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
 
         val first = SetAutoCloseTime.runDelayed(commandSender, doorRetriever);
         val second = SetAutoCloseTime.provideDelayedInput(commandSender, autoCloseValue);

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetBlocksToMoveTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetBlocksToMoveTest.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.doors.AbstractDoor;
 import nl.pim16aap2.bigdoors.doors.doorArchetypes.IDiscreteMovement;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.util.DoorRetriever;
 import org.junit.jupiter.api.Assertions;
@@ -85,7 +85,7 @@ class SetBlocksToMoveTest
     void testDelayedInput()
     {
         final int blocksToMove = 42;
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
 
         val first = SetBlocksToMove.runDelayed(commandSender, doorRetriever);
         val second = SetBlocksToMove.provideDelayedInput(commandSender, blocksToMove);

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetOpenDirectionTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/SetOpenDirectionTest.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.doors.AbstractDoor;
 import nl.pim16aap2.bigdoors.doortypes.DoorType;
-import nl.pim16aap2.bigdoors.localization.Localizer;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.util.DoorRetriever;
 import nl.pim16aap2.bigdoors.util.RotateDirection;
@@ -96,7 +96,7 @@ class SetOpenDirectionTest
     {
         final @NotNull RotateDirection rotateDirection = RotateDirection.CLOCKWISE;
         Mockito.when(doorType.isValidOpenDirection(rotateDirection)).thenReturn(true);
-        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(Localizer.class));
+        Mockito.when(platform.getLocalizer()).thenReturn(Mockito.mock(ILocalizer.class));
 
         val first = SetOpenDirection.runDelayed(commandSender, doorRetriever);
         val second = SetOpenDirection.provideDelayedInput(commandSender, rotateDirection);

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherTest.java
@@ -1,0 +1,17 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class LocalizationPatcherTest
+{
+    @Test
+    void isValidPatch()
+    {
+        Assertions.assertFalse(LocalizationPatcher.isValidPatch("key", "key="));
+        //noinspection ConstantConditions
+        Assertions.assertFalse(LocalizationPatcher.isValidPatch(null, "key="));
+        Assertions.assertTrue(LocalizationPatcher.isValidPatch("key", "key= "));
+        Assertions.assertTrue(LocalizationPatcher.isValidPatch("key", "key=value"));
+    }
+}

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilTest.java
@@ -1,6 +1,5 @@
 package nl.pim16aap2.bigdoors.localization;
 
-import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,6 +8,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
+import static nl.pim16aap2.bigdoors.localization.LocalizationUtil.*;
 
 class LocalizationUtilTest
 {
@@ -18,8 +20,8 @@ class LocalizationUtilTest
         final @NotNull String baseName = "Translation";
         final @NotNull List<Path> paths = new ArrayList<>(5);
 
-        val path0 = Paths.get("./" + baseName + ".properties");
-        val path1 = Paths.get("./" + baseName + "_en_US.properties");
+        final Path path0 = Paths.get("./" + baseName + ".properties");
+        final Path path1 = Paths.get("./" + baseName + "_en_US.properties");
 
         paths.add(path0);
         paths.add(path1);
@@ -31,12 +33,11 @@ class LocalizationUtilTest
         // (default file) or by _[locale].
         paths.add(Paths.get("./" + baseName + "nl_NL.txt"));
 
-
-        @NotNull val localeFiles = LocalizationUtil.getLocaleFiles(baseName, paths);
+        final List<LocaleFile> localeFiles = getLocaleFiles(baseName, paths);
         System.out.println(localeFiles);
         Assertions.assertEquals(2, localeFiles.size());
-        Assertions.assertEquals(new LocalizationUtil.LocaleFile(path0, ""), localeFiles.get(0));
-        Assertions.assertEquals(new LocalizationUtil.LocaleFile(path1, "en_US"), localeFiles.get(1));
+        Assertions.assertEquals(new LocaleFile(path0, ""), localeFiles.get(0));
+        Assertions.assertEquals(new LocaleFile(path1, "en_US"), localeFiles.get(1));
     }
 
     @Test
@@ -45,9 +46,9 @@ class LocalizationUtilTest
         final List<String> names = new ArrayList<>(3);
         names.add("translation.properties");
         names.add("translated_en_US.properties");
-        names.add("randomfile.txt");
+        names.add("randomFile.txt");
 
-        val localeFiles = LocalizationUtil.getLocaleFiles(names);
+        final List<LocaleFile> localeFiles = getLocaleFiles(names);
         Assertions.assertEquals(2, localeFiles.size());
         Assertions.assertEquals("", localeFiles.get(0).locale());
         Assertions.assertEquals("translation.properties", localeFiles.get(0).path().toString());
@@ -58,10 +59,10 @@ class LocalizationUtilTest
     @Test
     void testGetKeyFromLine()
     {
-        Assertions.assertEquals("key", LocalizationUtil.getKeyFromLine("key=value"));
-        Assertions.assertEquals("key", LocalizationUtil.getKeyFromLine("key=value=another_value"));
-        Assertions.assertNull(LocalizationUtil.getKeyFromLine("key"));
-        Assertions.assertNull(LocalizationUtil.getKeyFromLine(""));
+        Assertions.assertEquals("key", getKeyFromLine("key=value"));
+        Assertions.assertEquals("key", getKeyFromLine("key=value=another_value"));
+        Assertions.assertNull(getKeyFromLine("key"));
+        Assertions.assertNull(getKeyFromLine(""));
     }
 
     @Test
@@ -74,7 +75,7 @@ class LocalizationUtilTest
         input.add("key2=value2");
         input.add("key3=======");
 
-        val output = LocalizationUtil.getKeySet(input);
+        Set<String> output = getKeySet(input);
         Assertions.assertEquals(3, output.size());
         Assertions.assertTrue(output.contains("key"));
         Assertions.assertTrue(output.contains("key2"));
@@ -117,7 +118,7 @@ class LocalizationUtilTest
         newLines.addAll(lstB);
         newLines.addAll(lstC);
 
-        val appendable = LocalizationUtil.getAppendable(existing, newLines);
+        final List<String> appendable = getAppendable(existing, newLines);
         // Real appendable exists of only list C as all keys from lists B already exist in the "existing" list.
         Assertions.assertEquals(lstC, appendable);
     }
@@ -125,21 +126,20 @@ class LocalizationUtilTest
     @Test
     void testParseLocaleFileWithBaseName()
     {
-        Assertions.assertEquals("", LocalizationUtil.parseLocaleFile("Translation", "Translation.properties"));
-        Assertions.assertEquals("en_US",
-                                LocalizationUtil.parseLocaleFile("Translation", "Translation_en_US.properties"));
-        Assertions.assertNull(LocalizationUtil.parseLocaleFile("Translations", "Translation.properties"));
-        Assertions.assertNull(LocalizationUtil.parseLocaleFile("Translation", "Translation.txt"));
-        Assertions.assertNull(LocalizationUtil.parseLocaleFile("Translation", "Translated.properties"));
+        Assertions.assertEquals("", parseLocaleFile("Translation", "Translation.properties"));
+        Assertions.assertEquals("en_US", parseLocaleFile("Translation", "Translation_en_US.properties"));
+        Assertions.assertNull(parseLocaleFile("Translations", "Translation.properties"));
+        Assertions.assertNull(parseLocaleFile("Translation", "Translation.txt"));
+        Assertions.assertNull(parseLocaleFile("Translation", "Translated.properties"));
     }
 
     @Test
     void testParseLocaleFile()
     {
-        Assertions.assertEquals("", LocalizationUtil.parseLocaleFile("Translation.properties"));
-        Assertions.assertEquals("en_US", LocalizationUtil.parseLocaleFile("Translation_en_US.properties"));
-        Assertions.assertEquals("", LocalizationUtil.parseLocaleFile("Translation.properties"));
-        Assertions.assertEquals("", LocalizationUtil.parseLocaleFile("Translated.properties"));
-        Assertions.assertNull(LocalizationUtil.parseLocaleFile("Translation.txt"));
+        Assertions.assertEquals("", parseLocaleFile("Translation.properties"));
+        Assertions.assertEquals("en_US", parseLocaleFile("Translation_en_US.properties"));
+        Assertions.assertEquals("", parseLocaleFile("Translation.properties"));
+        Assertions.assertEquals("", parseLocaleFile("Translated.properties"));
+        Assertions.assertNull(parseLocaleFile("Translation.txt"));
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
@@ -156,7 +156,7 @@ class LocalizationGeneratorIntegrationTest
 
     @Test
     void testApplyPatches()
-        throws IOException
+        throws IOException, URISyntaxException
     {
         final Path jarFile = Files.createFile(directoryOutput.resolve(BASE_NAME + ".bundle"));
         final Map<String, String> patches = Map.of("a_key0", "a_key0= ",
@@ -170,12 +170,17 @@ class LocalizationGeneratorIntegrationTest
         localizationGenerator.applyPatches("", patches);
         localizationGenerator.applyPatches("en_US", patches);
 
-        final List<String> linesBase = LocalizationUtil.readFile(directoryOutput.resolve(BASE_NAME + ".bundle"));
+        final FileSystem fileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
+
+        final List<String> linesBase =
+            LocalizationUtil.readFile(Files.newInputStream(fileSystem.getPath(BASE_NAME + ".properties")));
+
         Assertions.assertEquals(List.of("a_key0= ", "a_key1=val1", "a_key2=val2",
                                         "a_key3=val3", "a_key4=val4", "a_key10=a_a_a_a"), linesBase);
 
         // The en_US file did not exist in the output bundle, so it should contain only the patches.
-        final List<String> linesEnUS = LocalizationUtil.readFile(directoryOutput.resolve(BASE_NAME + "en_US.bundle"));
+        final List<String> linesEnUS =
+            LocalizationUtil.readFile(Files.newInputStream(fileSystem.getPath(BASE_NAME + "_en_US.properties")));
         Assertions.assertEquals(List.of("a_key0= ", "a_key10=a_a_a_a"), linesEnUS);
     }
 
@@ -215,8 +220,7 @@ class LocalizationGeneratorIntegrationTest
         final FileSystem outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
         final Path outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
         final Path outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
-
-
+        
         Assertions.assertTrue(Files.exists(outputFile0));
         Assertions.assertTrue(Files.exists(outputFile1));
 

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
@@ -147,7 +147,7 @@ class LocalizationGeneratorIntegrationTest
 
         val dummyClass = Class.forName("org.example.project.LocalizationGeneratorDummyClass", true, loadJar(jarFile));
         val localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
-        localizationGenerator.addResources(dummyClass, null);
+        localizationGenerator.addResourcesFromClass(dummyClass, null);
 
         verifyJarOutput();
     }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -159,8 +160,9 @@ class LocalizationGeneratorIntegrationTest
         throws IOException, URISyntaxException
     {
         final Path jarFile = Files.createFile(directoryOutput.resolve(BASE_NAME + ".bundle"));
-        final Map<String, String> patches = Map.of("a_key0", "a_key0= ",
-                                                   "a_key10", "a_key10=a_a_a_a");
+        final Map<String, String> patches = new LinkedHashMap<>(2);
+        patches.put("a_key0", "a_key0= ");
+        patches.put("a_key10", "a_key10=a_a_a_a");
 
         final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(jarFile));
         writeEntry(outputStream, BASE_NAME + ".properties", INPUT_A_0);
@@ -220,7 +222,7 @@ class LocalizationGeneratorIntegrationTest
         final FileSystem outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
         final Path outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
         final Path outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
-        
+
         Assertions.assertTrue(Files.exists(outputFile0));
         Assertions.assertTrue(Files.exists(outputFile1));
 

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationGeneratorIntegrationTest.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.localization;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import lombok.val;
 import nl.pim16aap2.bigdoors.BigDoors;
 import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.logging.BasicPLogger;
@@ -32,26 +31,26 @@ import java.util.zip.ZipOutputStream;
 
 class LocalizationGeneratorIntegrationTest
 {
-    private static final @NotNull String BASE_NAME = "Translation";
-    private static final @NotNull String BASE_NAME_A = "Translation-A";
-    private static final @NotNull String BASE_NAME_B = "Translation-B";
+    private static final String BASE_NAME = "Translation";
+    private static final String BASE_NAME_A = "Translation-A";
+    private static final String BASE_NAME_B = "Translation-B";
 
-    private static final @NotNull List<String> INPUT_A_0 =
+    private static final List<String> INPUT_A_0 =
         List.of("a_key0=val0", "a_key1=val1", "a_key2=val2", "a_key3=val3", "a_key4=val4");
 
-    private static final @NotNull List<String> INPUT_A_1 =
+    private static final List<String> INPUT_A_1 =
         List.of("b_key0=val0", "b_key1=val1", "b_key2=val2", "b_key3=val3", "b_key4=val4");
 
-    private static final @NotNull List<String> INPUT_B_0 =
+    private static final List<String> INPUT_B_0 =
         List.of("a_key3=val100", "a_key4=val101", "a_key5=val102", "a_key6=val103", "a_key7=val104");
 
-    private static final @NotNull List<String> OUTPUT_0 = List.of(
+    private static final List<String> OUTPUT_0 = List.of(
         // From INPUT_A_0
         "a_key0=val0", "a_key1=val1", "a_key2=val2", "a_key3=val3", "a_key4=val4",
         // From INPUT_B_0
         "a_key5=val102", "a_key6=val103", "a_key7=val104");
 
-    private static final @NotNull List<String> OUTPUT_1 = List.of(
+    private static final List<String> OUTPUT_1 = List.of(
         // From INPUT_A_1
         "b_key0=val0", "b_key1=val1", "b_key2=val2", "b_key3=val3", "b_key4=val4");
 
@@ -74,7 +73,7 @@ class LocalizationGeneratorIntegrationTest
     void init()
         throws IOException
     {
-        val platform = Mockito.mock(IBigDoorsPlatform.class);
+        final IBigDoorsPlatform platform = Mockito.mock(IBigDoorsPlatform.class);
         BigDoors.get().setBigDoorsPlatform(platform);
         Mockito.when(platform.getPLogger()).thenReturn(new BasicPLogger());
 
@@ -93,24 +92,24 @@ class LocalizationGeneratorIntegrationTest
     void testAddResources()
         throws IOException, URISyntaxException
     {
-        val directoryA = Files.createDirectory(fs.getPath("/input_a"));
-        val directoryB = Files.createDirectory(fs.getPath("/input_b"));
+        final Path directoryA = Files.createDirectory(fs.getPath("/input_a"));
+        final Path directoryB = Files.createDirectory(fs.getPath("/input_b"));
 
-        val inputPathA0 = directoryA.resolve(BASE_NAME_A + ".properties");
-        val inputPathA1 = directoryA.resolve(BASE_NAME_A + "_en_US.properties");
-        val inputPathB0 = directoryB.resolve(BASE_NAME_B + ".properties");
+        final Path inputPathA0 = directoryA.resolve(BASE_NAME_A + ".properties");
+        final Path inputPathA1 = directoryA.resolve(BASE_NAME_A + "_en_US.properties");
+        final Path inputPathB0 = directoryB.resolve(BASE_NAME_B + ".properties");
 
         writeToFile(inputPathA0, INPUT_A_0);
         writeToFile(inputPathA1, INPUT_A_1);
         writeToFile(inputPathB0, INPUT_B_0);
 
-        val localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
+        final LocalizationGenerator localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
         localizationGenerator.addResources(directoryA, BASE_NAME_A);
         localizationGenerator.addResources(directoryB, BASE_NAME_B);
 
-        val outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
-        val outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
-        val outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
+        final FileSystem outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
+        final Path outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
+        final Path outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
 
         Assertions.assertEquals(OUTPUT_0, LocalizationUtil.readFile(Files.newInputStream(outputFile0)));
         Assertions.assertEquals(OUTPUT_1, LocalizationUtil.readFile(Files.newInputStream(outputFile1)));
@@ -126,10 +125,10 @@ class LocalizationGeneratorIntegrationTest
     void testAddResourcesFromJar()
         throws IOException, URISyntaxException
     {
-        val jarFile = Files.createFile(Files.createDirectory(fs.getPath("/input")).resolve("test.jar"));
+        final Path jarFile = Files.createFile(Files.createDirectory(fs.getPath("/input")).resolve("test.jar"));
         createJar(jarFile).close();
 
-        val localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
+        final LocalizationGenerator localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
         localizationGenerator.addResourcesFromZip(jarFile, null);
 
         verifyJarOutput();
@@ -139,14 +138,15 @@ class LocalizationGeneratorIntegrationTest
     void testAddResourcesFromClass()
         throws IOException, ClassNotFoundException, URISyntaxException
     {
-        val jarFile = Files.createFile(Files.createDirectory(fs.getPath("/input")).resolve("test.jar"));
-        val outputStream = createJar(jarFile);
+        final Path jarFile = Files.createFile(Files.createDirectory(fs.getPath("/input")).resolve("test.jar"));
+        final ZipOutputStream outputStream = createJar(jarFile);
         writeEntry(outputStream, "org/example/project/LocalizationGeneratorDummyClass.class",
                    LOCALIZATION_GENERATOR_DUMMY_CLASS_DATA);
         outputStream.close();
 
-        val dummyClass = Class.forName("org.example.project.LocalizationGeneratorDummyClass", true, loadJar(jarFile));
-        val localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
+        final Class<?> dummyClass = Class.forName("org.example.project.LocalizationGeneratorDummyClass", true,
+                                                  loadJar(jarFile));
+        final LocalizationGenerator localizationGenerator = new LocalizationGenerator(directoryOutput, BASE_NAME);
         localizationGenerator.addResourcesFromClass(dummyClass, null);
 
         verifyJarOutput();
@@ -161,9 +161,9 @@ class LocalizationGeneratorIntegrationTest
     private void verifyJarOutput()
         throws IOException, URISyntaxException
     {
-        val outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
-        val outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
-        val outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
+        final FileSystem outputFileSystem = createFileSystem(directoryOutput.resolve(BASE_NAME + ".bundle"));
+        final Path outputFile0 = outputFileSystem.getPath(BASE_NAME + ".properties");
+        final Path outputFile1 = outputFileSystem.getPath(BASE_NAME + "_en_US.properties");
 
 
         Assertions.assertTrue(Files.exists(outputFile0));
@@ -171,7 +171,7 @@ class LocalizationGeneratorIntegrationTest
 
         Assertions.assertEquals(INPUT_B_0, LocalizationUtil.readFile(Files.newInputStream(outputFile1)));
 
-        val outputBase = new ArrayList<>(10);
+        final List<String> outputBase = new ArrayList<>(10);
         outputBase.addAll(INPUT_A_0);
         outputBase.addAll(INPUT_A_1);
         Assertions.assertEquals(outputBase, LocalizationUtil.readFile(Files.newInputStream(outputFile0)));
@@ -189,7 +189,7 @@ class LocalizationGeneratorIntegrationTest
     private @NotNull ZipOutputStream createJar(@NotNull Path jarFile)
         throws IOException
     {
-        val outputStream = new ZipOutputStream(Files.newOutputStream(jarFile));
+        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(jarFile));
         writeEntry(outputStream, BASE_NAME_A + ".properties", INPUT_A_0);
         writeEntry(outputStream, BASE_NAME + ".properties", INPUT_A_1);
         writeEntry(outputStream, BASE_NAME_B + "_en_US.properties", INPUT_B_0);
@@ -237,8 +237,8 @@ class LocalizationGeneratorIntegrationTest
                                    @NotNull List<String> lines)
         throws IOException
     {
-        val sb = new StringBuilder();
-        for (val line : lines)
+        final StringBuilder sb = new StringBuilder();
+        for (final String line : lines)
             sb.append(line).append("\n");
         writeEntry(outputStream, fileName, sb.toString().getBytes());
     }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
@@ -1,0 +1,111 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import nl.pim16aap2.bigdoors.BigDoors;
+import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
+import nl.pim16aap2.bigdoors.api.IConfigLoader;
+import nl.pim16aap2.bigdoors.api.restartable.IRestartableHolder;
+import nl.pim16aap2.bigdoors.logging.BasicPLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.ZipOutputStream;
+
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.writeEntry;
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.writeToFile;
+
+class LocalizationManagerIntegrationTest
+{
+    private FileSystem fs;
+    private Path directoryOutput;
+
+    @BeforeEach
+    void init()
+        throws IOException
+    {
+        final IBigDoorsPlatform platform = Mockito.mock(IBigDoorsPlatform.class);
+        BigDoors.get().setBigDoorsPlatform(platform);
+        Mockito.when(platform.getPLogger()).thenReturn(new BasicPLogger());
+
+        fs = Jimfs.newFileSystem(Configuration.unix());
+        directoryOutput = Files.createDirectory(fs.getPath("/output"));
+    }
+
+    @AfterEach
+    void cleanup()
+        throws IOException
+    {
+        fs.close();
+    }
+
+    @Test
+    void testAvoidPatching()
+        throws IOException
+    {
+        final String baseName = "Translation";
+        final IConfigLoader configLoader = Mockito.mock(IConfigLoader.class);
+        Mockito.when(configLoader.locale()).thenReturn(Locale.ROOT);
+
+        final Path outputBundle = directoryOutput.resolve(baseName + ".bundle");
+        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(outputBundle));
+        writeEntry(outputStream, baseName + ".properties", List.of("key0=value0", "key1=value1", "key2=value2"));
+        outputStream.close();
+
+        final LocalizationManager localizationManager =
+            new LocalizationManager(Mockito.mock(IRestartableHolder.class), directoryOutput,
+                                    baseName, configLoader, -1);
+
+        localizationManager.restart();
+
+        // There aren't any patch files, so the patch generator should not be created
+        // either on startup or during a restart.
+        Assertions.assertFalse(localizationManager.isPatched());
+    }
+
+    @Test
+    void testPatching()
+        throws IOException
+    {
+        final String baseName = "Translation";
+        final IConfigLoader configLoader = Mockito.mock(IConfigLoader.class);
+        Mockito.when(configLoader.locale()).thenReturn(Locale.ROOT);
+
+        final List<String> baseItems = List.of("key0=value0", "key1=value1", "key2=value2",
+                                               "key3=value3", "key4=value4", "key5=value5");
+        final List<String> patchItems = List.of("key0=", "key3=remapped", "key6=value6");
+
+        final Path outputBundle = directoryOutput.resolve(baseName + ".bundle");
+
+        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(outputBundle));
+        writeEntry(outputStream, baseName + ".properties", baseItems);
+        outputStream.close();
+
+        final LocalizationManager localizationManager =
+            new LocalizationManager(Mockito.mock(IRestartableHolder.class), directoryOutput,
+                                    baseName, configLoader, -1);
+
+        Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
+        Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("key3"));
+        Assertions.assertEquals(Localizer.KEY_NOT_FOUND_MESSAGE + "key6",
+                                localizationManager.getLocalizer().getMessage("key6"));
+
+        writeToFile(directoryOutput.resolve(baseName + ".properties"), patchItems);
+
+        // Restarting the manager will apply all patches.
+        localizationManager.restart();
+
+        Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
+        Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("remapped"));
+        Assertions.assertEquals("value6", localizationManager.getLocalizer().getMessage("key6"));
+    }
+}

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
@@ -105,7 +105,7 @@ class LocalizationManagerIntegrationTest
         localizationManager.restart();
 
         Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
-        Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("remapped"));
+        Assertions.assertEquals("remapped", localizationManager.getLocalizer().getMessage("key3"));
         Assertions.assertEquals("value6", localizationManager.getLocalizer().getMessage("key6"));
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
@@ -63,7 +63,7 @@ class LocalizationManagerIntegrationTest
 
         final LocalizationManager localizationManager =
             new LocalizationManager(Mockito.mock(IRestartableHolder.class), directoryOutput,
-                                    baseName, configLoader, -1);
+                                    baseName, configLoader);
 
         localizationManager.restart();
 
@@ -91,8 +91,7 @@ class LocalizationManagerIntegrationTest
         outputStream.close();
 
         final LocalizationManager localizationManager =
-            new LocalizationManager(Mockito.mock(IRestartableHolder.class), directoryOutput,
-                                    baseName, configLoader, -1);
+            new LocalizationManager(Mockito.mock(IRestartableHolder.class), directoryOutput, baseName, configLoader);
 
         Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
         Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("key3"));

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
@@ -1,0 +1,63 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import nl.pim16aap2.bigdoors.BigDoors;
+import nl.pim16aap2.bigdoors.api.IBigDoorsPlatform;
+import nl.pim16aap2.bigdoors.logging.BasicPLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+class LocalizationPatcherIntegrationTest
+{
+    private FileSystem fs;
+    private Path directoryOutput;
+
+    @BeforeEach
+    void init()
+        throws IOException
+    {
+        final IBigDoorsPlatform platform = Mockito.mock(IBigDoorsPlatform.class);
+        BigDoors.get().setBigDoorsPlatform(platform);
+        Mockito.when(platform.getPLogger()).thenReturn(new BasicPLogger());
+
+        fs = Jimfs.newFileSystem(Configuration.unix());
+        directoryOutput = Files.createDirectory(fs.getPath("/output"));
+    }
+
+    @AfterEach
+    void cleanup()
+        throws IOException
+    {
+        fs.close();
+    }
+
+    @Test
+    void testUpdateRootKeys()
+        throws IOException
+    {
+        final Path file0 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
+        LocalizationUtil.appendToFile(file0, List.of("key0=aaa", "key1=aba", "key2=aab", "key3=baa"));
+
+        final Path file1 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch_en_US.properties"));
+        LocalizationUtil.appendToFile(file1, List.of("key10=aaa", "key11=aba", "key12=aab", "key13=baa"));
+
+        final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
+        patcher.updatePatchKeys(List.of("key1", "key4", "key5"));
+
+        Assertions.assertArrayEquals(new Object[]{"key0", "key1", "key2", "key3", "key4", "key5"},
+                                     LocalizationUtil.getKeySet(file0).toArray());
+
+        Assertions.assertArrayEquals(new Object[]{"key10", "key11", "key12", "key13", "key1", "key4", "key5"},
+                                     LocalizationUtil.getKeySet(file1).toArray());
+    }
+}

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
@@ -70,7 +70,7 @@ class LocalizationPatcherIntegrationTest
         LocalizationUtil.appendToFile(file, List.of("key0=", "key1= ", "key2=aab", "key3=baa"));
 
         final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
-        final Map<String, String> patches = patcher.getPatches("");
+        final Map<String, String> patches = patcher.getPatches(new LocaleFile(file, ""));
 
         final String[] patchedLines = patches.values().toArray(new String[0]);
         Assertions.assertArrayEquals(new String[]{"key1= ", "key2=aab", "key3=baa"}, patchedLines);

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
@@ -72,9 +72,7 @@ class LocalizationPatcherIntegrationTest
         final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
         final Map<String, String> patches = patcher.getPatches("");
 
-        Assertions.assertNull(patches.get("key0"));
-        Assertions.assertEquals(" ", patches.get("key1"));
-        Assertions.assertEquals("aab", patches.get("key2"));
-        Assertions.assertEquals("baa", patches.get("key3"));
+        final String[] patchedLines = patches.values().toArray(new String[0]);
+        Assertions.assertArrayEquals(new String[]{"key1= ", "key2=aab", "key3=baa"}, patchedLines);
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
@@ -16,6 +16,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 class LocalizationPatcherIntegrationTest
 {
@@ -59,5 +60,21 @@ class LocalizationPatcherIntegrationTest
 
         Assertions.assertArrayEquals(new Object[]{"key10", "key11", "key12", "key13", "key1", "key4", "key5"},
                                      LocalizationUtil.getKeySet(file1).toArray());
+    }
+
+    @Test
+    void testGetPatches()
+        throws IOException
+    {
+        final Path file = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
+        LocalizationUtil.appendToFile(file, List.of("key0=", "key1= ", "key2=aab", "key3=baa"));
+
+        final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
+        final Map<String, String> patches = patcher.getPatches("");
+
+        Assertions.assertNull(patches.get("key0"));
+        Assertions.assertEquals(" ", patches.get("key1"));
+        Assertions.assertEquals("aab", patches.get("key2"));
+        Assertions.assertEquals("baa", patches.get("key3"));
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationTestingUtilities.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationTestingUtilities.java
@@ -1,0 +1,118 @@
+package nl.pim16aap2.bigdoors.localization;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+class LocalizationTestingUtilities
+{
+
+    static @NotNull FileSystem createFileSystem(@NotNull Path zipFile)
+        throws URISyntaxException, IOException
+    {
+        return FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
+    }
+
+    /**
+     * Creates a new {@link URLClassLoader} and loads a jar with it.
+     *
+     * @param jar               The path to the jar to load.
+     * @param parentClassLoader The parent class loader.
+     * @return A new {@link URLClassLoader}.
+     *
+     * @throws MalformedURLException
+     */
+    static @NotNull URLClassLoader loadJar(@NotNull Path jar, ClassLoader parentClassLoader)
+        throws MalformedURLException
+    {
+        return new URLClassLoader("URLClassLoader_LocalizationGeneratorIntegrationTest",
+                                  new URL[]{jar.toUri().toURL()}, parentClassLoader);
+    }
+
+    static void addFilesToZip(@NotNull Path zipFile, @NotNull String... names)
+        throws IOException
+    {
+        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(zipFile));
+        for (final String name : names)
+        {
+            final byte[] data = "".getBytes();
+            outputStream.putNextEntry(new ZipEntry(name));
+            outputStream.write(data, 0, data.length);
+            outputStream.closeEntry();
+        }
+        outputStream.close();
+    }
+
+    /**
+     * Appends a list of Strings to a file. Each entry in the list will be printed on its own line.
+     *
+     * @param file  The file to append the lines to.
+     * @param lines The lines to write to the file.
+     * @throws IOException
+     */
+    static void writeToFile(@NotNull Path file, @NotNull List<String> lines)
+        throws IOException
+    {
+        LocalizationUtil.ensureFileExists(file);
+        LocalizationUtil.appendToFile(file, lines);
+    }
+
+    /**
+     * Writes a new entry (file) in a zip file.
+     *
+     * @param outputStream The output stream to write the new entry to.
+     * @param fileName     The name of the entry (file) to write in the zip file.
+     * @param lines        The lines to write to the entry.
+     * @throws IOException
+     */
+    static void writeEntry(@NotNull ZipOutputStream outputStream, @NotNull String fileName,
+                           @NotNull List<String> lines)
+        throws IOException
+    {
+        final StringBuilder sb = new StringBuilder();
+        for (final String line : lines)
+            sb.append(line).append("\n");
+        writeEntry(outputStream, fileName, sb.toString().getBytes());
+    }
+
+
+    /**
+     * Writes a new entry (file) in a zip file.
+     *
+     * @param outputStream The output stream to write the new entry to.
+     * @param fileName     The name of the entry (file) to write in the zip file.
+     * @param data         The data to write to the entry.
+     * @throws IOException
+     */
+    static void writeEntry(@NotNull ZipOutputStream outputStream, @NotNull String fileName,
+                           byte[] data)
+        throws IOException
+    {
+        outputStream.putNextEntry(new ZipEntry(fileName));
+        outputStream.write(data, 0, data.length);
+        outputStream.closeEntry();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    static void appendToFile(@NotNull Path zipFile, @NotNull String file, @NotNull String toAppend)
+        throws URISyntaxException, IOException
+    {
+        final FileSystem bundleFileSystem = FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
+        Files.write(bundleFileSystem.getPath(file), toAppend.getBytes(), StandardOpenOption.APPEND);
+        bundleFileSystem.close();
+    }
+}

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationTestingUtilities.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationTestingUtilities.java
@@ -108,7 +108,7 @@ class LocalizationTestingUtilities
     }
 
     @SuppressWarnings("SameParameterValue")
-    static void appendToFile(@NotNull Path zipFile, @NotNull String file, @NotNull String toAppend)
+    static void appendToFileInZip(@NotNull Path zipFile, @NotNull String file, @NotNull String toAppend)
         throws URISyntaxException, IOException
     {
         final FileSystem bundleFileSystem = FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.localization;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,12 +9,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.addFilesToZip;
+
 
 class LocalizationUtilIntegrationTest
 {
@@ -54,19 +53,5 @@ class LocalizationUtilIntegrationTest
         Assertions.assertTrue(locales.contains(new Locale("en", "US", "some_random_variation")));
         Assertions.assertTrue(locales.contains(new Locale("nl")));
         Assertions.assertTrue(locales.contains(new Locale("nl", "NL")));
-    }
-
-    private void addFilesToZip(@NotNull Path zipFile, @NotNull String... names)
-        throws IOException
-    {
-        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(zipFile));
-        for (final String name : names)
-        {
-            final byte[] data = "".getBytes();
-            outputStream.putNextEntry(new ZipEntry(name));
-            outputStream.write(data, 0, data.length);
-            outputStream.closeEntry();
-        }
-        outputStream.close();
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.localization;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -13,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -38,8 +38,8 @@ class LocalizationUtilIntegrationTest
     void testGetLocalesInDirectory()
         throws IOException
     {
-        val zipFile = fs.getPath("./test.jar");
-        val base = "translation";
+        final Path zipFile = fs.getPath("./test.jar");
+        final String base = "translation";
         addFilesToZip(zipFile,
                       base + ".properties",
                       base + "_en_us.properties",
@@ -47,7 +47,7 @@ class LocalizationUtilIntegrationTest
                       base + "_nl.properties",
                       base + "_nl_NL.properties");
 
-        val locales = LocalizationUtil.getLocalesInZip(zipFile, base);
+        final List<Locale> locales = LocalizationUtil.getLocalesInZip(zipFile, base);
         Assertions.assertEquals(5, locales.size());
         Assertions.assertTrue(locales.contains(Locale.ROOT));
         Assertions.assertTrue(locales.contains(Locale.US));
@@ -59,10 +59,10 @@ class LocalizationUtilIntegrationTest
     private void addFilesToZip(@NotNull Path zipFile, @NotNull String... names)
         throws IOException
     {
-        val outputStream = new ZipOutputStream(Files.newOutputStream(zipFile));
-        for (val name : names)
+        final ZipOutputStream outputStream = new ZipOutputStream(Files.newOutputStream(zipFile));
+        for (final String name : names)
         {
-            val data = "".getBytes();
+            final byte[] data = "".getBytes();
             outputStream.putNextEntry(new ZipEntry(name));
             outputStream.write(data, 0, data.length);
             outputStream.closeEntry();

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.localization;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -49,7 +48,7 @@ class LocalizerIntegrationTest
         initPlatform();
         initFileSystem();
 
-        val zipOutputStream = new ZipOutputStream(Files.newOutputStream(bundle));
+        final ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(bundle));
         String baseFileContents = """
                                   key0=value0
                                   key1=value1
@@ -74,9 +73,9 @@ class LocalizerIntegrationTest
     @Test
     void testGetMessage()
     {
-        val localizer = new Localizer(directory, BASE_NAME);
+        final Localizer localizer = new Localizer(directory, BASE_NAME);
         Assertions.assertEquals("waarde0", localizer.getMessage("key0", LOCALE_DUTCH));
-        val input = "A_B_C_D_E";
+        final String input = "A_B_C_D_E";
         Assertions.assertEquals(input, localizer.getMessage("key1", LOCALE_DUTCH, input));
         Assertions.assertEquals("value1", localizer.getMessage("key1", input));
         Assertions.assertEquals("value2", localizer.getMessage("key2", LOCALE_DUTCH, input));
@@ -86,7 +85,7 @@ class LocalizerIntegrationTest
     void testAppendingMessages()
         throws IOException, URISyntaxException
     {
-        val localizer = new Localizer(directory, BASE_NAME);
+        final Localizer localizer = new Localizer(directory, BASE_NAME);
         // Just ensure that it's loaded properly.
         Assertions.assertEquals("value0", localizer.getMessage("key0"));
         // Ensure that the key doesn't exist (yet!).
@@ -95,7 +94,7 @@ class LocalizerIntegrationTest
         localizer.shutdown();
         Assertions.assertEquals(Localizer.KEY_NOT_FOUND_MESSAGE + "key0", localizer.getMessage("key0"));
 
-        val value3 = "THIS WAS JUST ADDED! DID ANYONE SEE THAT?";
+        final String value3 = "THIS WAS JUST ADDED! DID ANYONE SEE THAT?";
         appendToFile(bundle, BASE_NAME + ".properties", "key3=" + value3);
 
         localizer.reInit();
@@ -107,7 +106,7 @@ class LocalizerIntegrationTest
     private void appendToFile(@NotNull Path zipFile, @NotNull String file, @NotNull String toAppend)
         throws URISyntaxException, IOException
     {
-        val bundleFileSystem = FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
+        final FileSystem bundleFileSystem = FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
         Files.write(bundleFileSystem.getPath(file), toAppend.getBytes(), StandardOpenOption.APPEND);
         bundleFileSystem.close();
     }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 import java.util.zip.ZipOutputStream;
 
 import static nl.pim16aap2.bigdoors.UnitTestUtil.initPlatform;
-import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.appendToFile;
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.appendToFileInZip;
 import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.writeEntry;
 
 
@@ -92,7 +92,7 @@ class LocalizerIntegrationTest
         Assertions.assertEquals(Localizer.KEY_NOT_FOUND_MESSAGE + "key0", localizer.getMessage("key0"));
 
         final String value3 = "THIS WAS JUST ADDED! DID ANYONE SEE THAT?";
-        appendToFile(bundle, BASE_NAME + ".properties", "key3=" + value3);
+        appendToFileInZip(bundle, BASE_NAME + ".properties", "key3=" + value3);
 
         localizer.reInit();
         Assertions.assertEquals("value0", localizer.getMessage("key0"));

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -9,19 +9,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Locale;
-import java.util.Map;
 import java.util.zip.ZipOutputStream;
 
 import static nl.pim16aap2.bigdoors.UnitTestUtil.initPlatform;
-import static nl.pim16aap2.bigdoors.localization.LocalizationGeneratorIntegrationTest.writeEntry;
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.appendToFile;
+import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.writeEntry;
 
 
 class LocalizerIntegrationTest
@@ -100,14 +97,5 @@ class LocalizerIntegrationTest
         localizer.reInit();
         Assertions.assertEquals("value0", localizer.getMessage("key0"));
         Assertions.assertEquals(value3, localizer.getMessage("key3"));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private void appendToFile(@NotNull Path zipFile, @NotNull String file, @NotNull String toAppend)
-        throws URISyntaxException, IOException
-    {
-        final FileSystem bundleFileSystem = FileSystems.newFileSystem(new URI("jar:" + zipFile.toUri()), Map.of());
-        Files.write(bundleFileSystem.getPath(file), toAppend.getBytes(), StandardOpenOption.APPEND);
-        bundleFileSystem.close();
     }
 }

--- a/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -98,7 +98,7 @@ class LocalizerIntegrationTest
         val value3 = "THIS WAS JUST ADDED! DID ANYONE SEE THAT?";
         appendToFile(bundle, BASE_NAME + ".properties", "key3=" + value3);
 
-        localizer.restart();
+        localizer.reInit();
         Assertions.assertEquals("value0", localizer.getMessage("key0"));
         Assertions.assertEquals(value3, localizer.getMessage("key3"));
     }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
@@ -344,7 +344,7 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
                                                     .map(DoorType::getDoorClass)
                                                     .collect(Collectors.toList());
         localizationManager = new LocalizationManager(this, getDataDirectory().toPath().resolve(""), "translations",
-                                                      getConfigLoader(), -1);
+                                                      getConfigLoader());
         localizationManager.addResourcesFromClass(types);
         localizationManager.addResourcesFromClass(List.of(getClass()));
         localizer = localizationManager.getLocalizer();

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
@@ -29,8 +29,8 @@ import nl.pim16aap2.bigdoors.doors.DoorOpener;
 import nl.pim16aap2.bigdoors.doortypes.DoorType;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEvent;
 import nl.pim16aap2.bigdoors.extensions.DoorTypeLoader;
+import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.localization.LocalizationManager;
-import nl.pim16aap2.bigdoors.localization.Localizer;
 import nl.pim16aap2.bigdoors.logging.IPLogger;
 import nl.pim16aap2.bigdoors.logging.PLogger;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
@@ -192,7 +192,7 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
     private final @NotNull DelayedCommandInputManager delayedCommandInputManager = new DelayedCommandInputManager();
 
     @Getter
-    private Localizer localizer;
+    private ILocalizer localizer;
 
     private LocalizationManager localizationManager;
 
@@ -347,7 +347,7 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
                                                       getConfigLoader(), -1);
         localizationManager.addResourcesFromClass(types);
         localizationManager.addResourcesFromClass(List.of(getClass()));
-        this.localizer = localizationManager.getLocalizer();
+        localizer = localizationManager.getLocalizer();
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.bigdoors.spigot;
 
 import lombok.Getter;
-import lombok.val;
 import nl.pim16aap2.bigdoors.BigDoors;
 import nl.pim16aap2.bigdoors.annotations.Initializer;
 import nl.pim16aap2.bigdoors.api.DebugReporter;
@@ -30,7 +29,7 @@ import nl.pim16aap2.bigdoors.doors.DoorOpener;
 import nl.pim16aap2.bigdoors.doortypes.DoorType;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEvent;
 import nl.pim16aap2.bigdoors.extensions.DoorTypeLoader;
-import nl.pim16aap2.bigdoors.localization.LocalizationGenerator;
+import nl.pim16aap2.bigdoors.localization.LocalizationManager;
 import nl.pim16aap2.bigdoors.localization.Localizer;
 import nl.pim16aap2.bigdoors.logging.IPLogger;
 import nl.pim16aap2.bigdoors.logging.PLogger;
@@ -86,7 +85,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -112,7 +111,7 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
 
     private boolean validVersion = false;
     private final @NotNull IPExecutor pExecutor;
-    private final Set<IRestartable> restartables = new HashSet<>();
+    private final Set<IRestartable> restartables = new LinkedHashSet<>();
 
     @Getter
     private ProtectionCompatManagerSpigot protectionCompatManager;
@@ -194,6 +193,8 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
 
     @Getter
     private Localizer localizer;
+
+    private LocalizationManager localizationManager;
 
     public BigDoorsSpigot()
     {
@@ -336,19 +337,17 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
 
     private void initLocalization()
     {
+        if (localizationManager != null)
+            return;
+
         final List<Class<?>> types = doorTypeManager.getEnabledDoorTypes().stream()
                                                     .map(DoorType::getDoorClass)
                                                     .collect(Collectors.toList());
-        val generator = new LocalizationGenerator(getDataDirectory().toPath(), "translations");
-
-        if (localizer == null)
-        {
-            generator.addResources(types);
-            generator.addResources(List.of(getClass()));
-            localizer = new Localizer(getDataDirectory().toPath(), "translations", getConfigLoader().locale());
-        }
-        else
-            generator.addResources(localizer, types);
+        localizationManager = new LocalizationManager(this, getDataDirectory().toPath(), "translations",
+                                                      getConfigLoader(), -1);
+        localizationManager.addResourcesFromClass(types);
+        localizationManager.addResourcesFromClass(List.of(getClass()));
+        this.localizer = localizationManager.getLocalizer();
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsSpigot.java
@@ -343,7 +343,7 @@ public final class BigDoorsSpigot extends BigDoorsSpigotAbstract
         final List<Class<?>> types = doorTypeManager.getEnabledDoorTypes().stream()
                                                     .map(DoorType::getDoorClass)
                                                     .collect(Collectors.toList());
-        localizationManager = new LocalizationManager(this, getDataDirectory().toPath(), "translations",
+        localizationManager = new LocalizationManager(this, getDataDirectory().toPath().resolve(""), "translations",
                                                       getConfigLoader(), -1);
         localizationManager.addResourcesFromClass(types);
         localizationManager.addResourcesFromClass(List.of(getClass()));


### PR DESCRIPTION
Updated localization system to include a patching mechanism. 

The new system works as follows:
- It creates a `Translations.bundle` (zip) file which contains the default .properties files. This file will be regenerated regularly, so users shouldn't interact with it.
- On startup, a `Translations.properties` file is created which contains all the keys without any values (e.g. `door.type.big_door=`). 
This properties file never gets regenerated, but if any keys are added via an update, they will be appended. 
- When the `Translations.properties` contains a value for 1 or more keys (e.g. `door.type.big_door=Biggus Doorus`), a new bundle will be generated: `Translations_patched.bundle`. This patched bundle in a combination of the base bundle and the properties file, where the properties file overrides the values in the base bundle. 
- Lastly, it's possible to create overrides for different locales as well by simply appending the locale to the properties file (e.g. `Translations_nl_NL.properties`).

This way, updates can easily change localization strings without overriding changes made by users.