### PR TITLE
Fix stair rotation in cardinal direction

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/BlockFace.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/BlockFace.java
@@ -240,7 +240,7 @@ public enum BlockFace
      *     The {@link MovementDirection} to rotate in.
      * @return The appropriate function for rotating the {@link BlockFace} in the given direction.
      */
-    public static @Nullable UnaryOperator<BlockFace> getDirFun(MovementDirection movementDirection)
+    public static @Nullable UnaryOperator<BlockFace> getRotationFunction(MovementDirection movementDirection)
     {
         return switch (movementDirection)
         {
@@ -261,16 +261,17 @@ public enum BlockFace
      *     The {@link BlockFace} that will be rotated.
      * @param steps
      *     The number of times to apply the rotation.
-     * @param dir
+     * @param rotationFunction
      *     The function the applies the rotation.
      * @return The rotated {@link BlockFace}.
      *
-     * @see BlockFace#getDirFun
+     * @see BlockFace#getRotationFunction
      */
-    public static BlockFace rotate(BlockFace blockFace, int steps, UnaryOperator<BlockFace> dir)
+    public static BlockFace rotate(BlockFace blockFace, int steps, @Nullable UnaryOperator<BlockFace> rotationFunction)
     {
-        if (blockFace.equals(BlockFace.NONE))
+        if (rotationFunction == null || blockFace.equals(BlockFace.NONE))
             return blockFace;
+
         // Every 4 steps results in the same outcome.
         int realSteps = steps % 4;
         if (realSteps == 0)
@@ -278,7 +279,23 @@ public enum BlockFace
 
         BlockFace newFace = blockFace;
         while (realSteps-- > 0)
-            newFace = dir.apply(blockFace);
+            newFace = rotationFunction.apply(newFace);
         return newFace;
+    }
+
+    /**
+     * Rotate a block face in a given direction for a number of steps.
+     *
+     * @param blockFace
+     *     The {@link BlockFace} that will be rotated.
+     * @param steps
+     *     The number of times to apply the rotation.
+     * @param direction
+     *     The direction to rotate in.
+     * @return The rotated {@link BlockFace}.
+     */
+    public static BlockFace rotate(BlockFace blockFace, int steps, MovementDirection direction)
+    {
+        return rotate(blockFace, steps, getRotationFunction(direction));
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/MovementDirection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/MovementDirection.java
@@ -4,9 +4,11 @@ import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents all possible movement directions of a Structure.
@@ -42,6 +44,12 @@ public enum MovementDirection
         ID_MAP = Collections.unmodifiableMap(idMapTmp);
         NAME_MAP = Collections.unmodifiableMap(nameMapTmp);
     }
+
+    /**
+     * Unmodifiable set of the four cardinal directions; north, east, south, and west.
+     */
+    public static final Set<MovementDirection> CARDINAL_DIRECTIONS =
+        Collections.unmodifiableSet(EnumSet.of(NORTH, EAST, SOUTH, WEST));
 
     private final int val;
 
@@ -85,6 +93,13 @@ public enum MovementDirection
         }
     }
 
+    /**
+     * Gets the {@link MovementDirection} from a name.
+     *
+     * @param name
+     *     The name of the {@link MovementDirection}.
+     * @return The {@link MovementDirection} associated with this name.
+     */
     public static Optional<MovementDirection> getMovementDirection(String name)
     {
         return Optional.ofNullable(NAME_MAP.get(name));
@@ -112,5 +127,17 @@ public enum MovementDirection
             case COUNTERCLOCKWISE -> MovementDirection.CLOCKWISE;
             default -> MovementDirection.NONE;
         };
+    }
+
+    /**
+     * Check if the provided {@link MovementDirection} is a cardinal direction.
+     *
+     * @param direction
+     *     The {@link MovementDirection} to check.
+     * @return True if the provided {@link MovementDirection} is a cardinal direction, false otherwise.
+     */
+    public static boolean isCardinalDirection(@Nullable MovementDirection direction)
+    {
+        return direction != null && CARDINAL_DIRECTIONS.contains(direction);
     }
 }


### PR DESCRIPTION
- Applying multiple rotation steps in one go had no effect over a single rotation, as successive rotations did not use the previous result. Instead, it used the input value over and over... Currently, this is only used for stairs (which need to be rotated twice when rotated in NORTH/EAST/SOUTH/WEST direction).