### PR TITLE
🤖 Add LightKeeper E2E integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,20 @@ on:
 env:
   MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # The javadoc deploy step pushes to the gh-pages branch on release/** pushes.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -74,6 +82,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,19 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build the project and run static analysis tools.
-        run: mvn --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
+        run: mvn -U --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
+
+      - name: Upload LightKeeper diagnostics
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: LightKeeper diagnostics
+          path: |
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/failsafe-reports/**
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/logs/**
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/crash-reports/**
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Build the javadocs
         run: mvn --batch-mode -P=docs -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,23 +38,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Invalidate LightKeeper snapshot cache
-        run: rm -rf ~/.m2/repository/nl/pim16aap2/lightkeeper
-
       - name: Build the project and run static analysis tools.
         run: mvn --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
-
-      - name: Upload LightKeeper diagnostics
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: failure()
-        with:
-          name: LightKeeper diagnostics
-          path: |
-            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/failsafe-reports/**
-            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/logs/**
-            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/crash-reports/**
-          if-no-files-found: ignore
-          retention-days: 7
 
       - name: Build the javadocs
         run: mvn --batch-mode -P=docs -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
@@ -82,3 +67,83 @@ jobs:
         with:
           directory: report-aggregate/target/site/jacoco-aggregate
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Server jars, prepared base servers, and downloaded plugins live in their own
+      # cache: they only need to be invalidated when the e2e configuration changes,
+      # which is far less often than the Maven repository cache. Saved keys carry a
+      # content hash (see the save step below), so the primary key never matches
+      # exactly and restore-keys restore the newest matching entry.
+      - name: Restore LightKeeper server cache
+        id: lightkeeper-cache-restore
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/lightkeeper
+          key: ${{ runner.os }}-lightkeeper-${{ hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml') }}-
+          restore-keys: |
+            ${{ runner.os }}-lightkeeper-${{ hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml') }}-
+            ${{ runner.os }}-lightkeeper-
+
+      - name: Build the AnimatedArchitecture plugin
+        run: mvn --batch-mode -DskipTests install -pl animatedarchitecture-spigot/spigot-packager -am
+
+      # -U checks EldoNexus for a newer LightKeeper snapshot on every run without
+      # discarding the download caches above.
+      - name: Run LightKeeper end-to-end tests
+        run: >
+          mvn --batch-mode -U -P=lightkeeper-e2e -pl :animatedarchitecture-lightkeeper-e2e verify
+          -Dlightkeeper.jarCacheDirectoryRoot=$HOME/.cache/lightkeeper/jars
+          -Dlightkeeper.baseServerCacheDirectoryRoot=$HOME/.cache/lightkeeper/server
+          -Dlightkeeper.pluginArtifactCacheDirectoryRoot=$HOME/.cache/lightkeeper/plugins
+
+      - name: Upload LightKeeper diagnostics
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: LightKeeper diagnostics
+          path: |
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/failsafe-reports/**
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/logs/**
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/crash-reports/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Save the cache only when its content actually changed (new server version,
+      # rebuilt jar, expiry pruning). The key embeds a content hash: unchanged
+      # content computes the key that was just restored, and the save is skipped.
+      # Superseded entries stop being restored and GitHub evicts caches that go
+      # unaccessed for 7 days, so only the newest entry sticks around. This runs
+      # even when tests fail, so expensive downloads/builds are never repeated.
+      - name: Hash LightKeeper server cache
+        id: lightkeeper-cache-state
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p ~/.cache/lightkeeper
+          echo "hash=$(find ~/.cache/lightkeeper -type f -print0 | sort -z | xargs -0 -r sha256sum | sha256sum | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+      - name: Save LightKeeper server cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        if: ${{ !cancelled() && steps.lightkeeper-cache-restore.outputs.cache-matched-key != format('{0}-lightkeeper-{1}-{2}', runner.os, hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml'), steps.lightkeeper-cache-state.outputs.hash) }}
+        with:
+          path: ~/.cache/lightkeeper
+          key: ${{ runner.os }}-lightkeeper-${{ hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml') }}-${{ steps.lightkeeper-cache-state.outputs.hash }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
             animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/failsafe-reports/**
             animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/logs/**
             animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/crash-reports/**
+            animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/target/lightkeeper-server/**/plugins/AnimatedArchitecture/*.log
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,18 +81,18 @@ jobs:
     needs: build
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Cache local Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -106,7 +106,7 @@ jobs:
       # exactly and restore-keys restore the newest matching entry.
       - name: Restore LightKeeper server cache
         id: lightkeeper-cache-restore
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/lightkeeper
           key: ${{ runner.os }}-lightkeeper-${{ hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml') }}-
@@ -127,7 +127,7 @@ jobs:
           -Dlightkeeper.pluginArtifactCacheDirectoryRoot=$HOME/.cache/lightkeeper/plugins
 
       - name: Upload LightKeeper diagnostics
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: LightKeeper diagnostics
@@ -152,7 +152,7 @@ jobs:
           echo "hash=$(find ~/.cache/lightkeeper -type f -print0 | sort -z | xargs -0 -r sha256sum | sha256sum | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Save LightKeeper server cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: ${{ !cancelled() && steps.lightkeeper-cache-restore.outputs.cache-matched-key != format('{0}-lightkeeper-{1}-{2}', runner.os, hashFiles('animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml'), steps.lightkeeper-cache-state.outputs.hash) }}
         with:
           path: ~/.cache/lightkeeper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # The javadoc deploy step pushes to the gh-pages branch on release/** pushes.
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -49,10 +46,6 @@ jobs:
       - name: Build the project and run static analysis tools.
         run: mvn --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
 
-      - name: Build the javadocs
-        run: mvn --batch-mode -P=docs -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
-
       - name: Upload AnimatedArchitecture-Spigot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -62,19 +55,49 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          directory: report-aggregate/target/site/jacoco-aggregate
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Runs only on release/** pushes, in its own job so that the gh-pages write
+  # permission is never granted to pull_request builds.
+  javadoc:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build the javadocs
+        run: mvn --batch-mode -P=docs -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
+
       - name: Deploy Javadoc
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: target/reports/apidocs
           target-folder: javadoc
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          directory: report-aggregate/target/site/jacoco-aggregate
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Invalidate LightKeeper snapshot cache
+        run: rm -rf ~/.m2/repository/nl/pim16aap2/lightkeeper
+
       - name: Build the project and run static analysis tools.
-        run: mvn -U --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
+        run: mvn --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
 
       - name: Upload LightKeeper diagnostics
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgumentFactory.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgumentFactory.java
@@ -89,7 +89,7 @@ public final class TextArgumentFactory
      */
     public TextArgument localizedHighlight(StructureType structureType)
     {
-        return highlight(structureType.getLocalizationKey());
+        return localizedHighlight(structureType.getLocalizationKey());
     }
 
     /**
@@ -143,7 +143,7 @@ public final class TextArgumentFactory
      */
     public TextArgument localizedInfo(StructureType structureType)
     {
-        return info(structureType.getLocalizationKey());
+        return localizedInfo(structureType.getLocalizationKey());
     }
 
     /**

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgumentFactoryTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgumentFactoryTest.java
@@ -1,0 +1,81 @@
+package nl.pim16aap2.animatedarchitecture.core.text;
+
+import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.localization.PersonalizedLocalizer;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TextArgumentFactoryTest
+{
+    private static final String LOCALIZATION_KEY = "structure.type.portcullis";
+    private static final String LOCALIZED_VALUE = "Portcullis";
+
+    @Mock
+    private ILocalizer localizer;
+
+    @Mock
+    private ITextComponentFactory textComponentFactory;
+
+    @Mock
+    private StructureType structureType;
+
+    @Test
+    void localizedHighlight_shouldLocalizeStructureTypeKey()
+    {
+        // setup
+        final TextComponent component = new TextComponent();
+        when(structureType.getLocalizationKey()).thenReturn(LOCALIZATION_KEY);
+        when(localizer.getMessage(LOCALIZATION_KEY, (Locale) null)).thenReturn(LOCALIZED_VALUE);
+        when(textComponentFactory.newComponent(TextType.HIGHLIGHT)).thenReturn(component);
+        final TextArgumentFactory factory =
+            new TextArgumentFactory(textComponentFactory, new PersonalizedLocalizer(localizer, null));
+
+        // execute
+        final TextArgument result = factory.localizedHighlight(structureType);
+
+        // verify
+        assertThat(result.argument()).isEqualTo(LOCALIZED_VALUE);
+        assertThat(result.component()).isSameAs(component);
+    }
+
+    @Test
+    void localizedInfo_shouldLocalizeStructureTypeKey()
+    {
+        // setup
+        final TextComponent component = new TextComponent();
+        when(structureType.getLocalizationKey()).thenReturn(LOCALIZATION_KEY);
+        when(localizer.getMessage(LOCALIZATION_KEY, (Locale) null)).thenReturn(LOCALIZED_VALUE);
+        when(textComponentFactory.newComponent(TextType.INFO)).thenReturn(component);
+        final TextArgumentFactory factory =
+            new TextArgumentFactory(textComponentFactory, new PersonalizedLocalizer(localizer, null));
+
+        // execute
+        final TextArgument result = factory.localizedInfo(structureType);
+
+        // verify
+        assertThat(result.argument()).isEqualTo(LOCALIZED_VALUE);
+        assertThat(result.component()).isSameAs(component);
+    }
+
+    @Test
+    void localized_shouldReturnKeyWhenLocalizerIsNull()
+    {
+        // setup
+        final TextArgumentFactory factory = new TextArgumentFactory(textComponentFactory, null);
+
+        // execute
+        final String result = factory.localized(LOCALIZATION_KEY);
+
+        // verify
+        assertThat(result).isEqualTo(LOCALIZATION_KEY);
+    }
+}

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/AnimatedArchitectureToolUtilSpigot.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/AnimatedArchitectureToolUtilSpigot.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.CustomLog;
 import nl.pim16aap2.animatedarchitecture.core.api.IAnimatedArchitectureToolUtil;
+import nl.pim16aap2.animatedarchitecture.core.api.IExecutor;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.util.reflection.ReflectionBuilder;
 import org.bukkit.Bukkit;
@@ -40,11 +41,13 @@ public class AnimatedArchitectureToolUtilSpigot implements IAnimatedArchitecture
         .get(null);
 
     private final NamespacedKey animatedArchitectureToolKey;
+    private final IExecutor executor;
 
     @Inject
-    public AnimatedArchitectureToolUtilSpigot(JavaPlugin javaPlugin)
+    public AnimatedArchitectureToolUtilSpigot(JavaPlugin javaPlugin, IExecutor executor)
     {
         animatedArchitectureToolKey = new NamespacedKey(javaPlugin, "ANIMATED_ARCHITECTURE_TOOL");
+        this.executor = executor;
     }
 
     @Override
@@ -74,12 +77,16 @@ public class AnimatedArchitectureToolUtilSpigot implements IAnimatedArchitecture
         itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         tool.setItemMeta(itemMeta);
 
-        // TODO: Make sure to give the item in their current slot, moving items if needed.
-        final int heldSlot = spigotPlayer.getInventory().getHeldItemSlot();
-        if (spigotPlayer.getInventory().getItem(heldSlot) == null)
-            spigotPlayer.getInventory().setItem(heldSlot, tool);
-        else
-            spigotPlayer.getInventory().addItem(tool);
+        // Inventory mutation must happen on the main thread; input handling may run off-main.
+        executor.runOnMainThread(() ->
+        {
+            // TODO: Make sure to give the item in their current slot, moving items if needed.
+            final int heldSlot = spigotPlayer.getInventory().getHeldItemSlot();
+            if (spigotPlayer.getInventory().getItem(heldSlot) == null)
+                spigotPlayer.getInventory().setItem(heldSlot, tool);
+            else
+                spigotPlayer.getInventory().addItem(tool);
+        });
     }
 
     @Override
@@ -92,11 +99,13 @@ public class AnimatedArchitectureToolUtilSpigot implements IAnimatedArchitecture
             return;
         }
 
-        spigotPlayer.getInventory().forEach(item ->
-        {
-            if (isTool(item))
-                item.setAmount(0);
-        });
+        // Inventory mutation must happen on the main thread; input handling may run off-main.
+        executor.runOnMainThread(() ->
+            spigotPlayer.getInventory().forEach(item ->
+            {
+                if (isTool(item))
+                    item.setAmount(0);
+            }));
     }
 
     public boolean isTool(@Nullable ItemStack item)

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
@@ -26,6 +26,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
+import org.bukkit.event.world.EntitiesLoadEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.List;
@@ -105,15 +106,21 @@ public class ChunkListener extends AbstractListener
     }
 
     /**
-     * Listens to chunks being loaded and checks if there are any animated blocks in it that need to be recovered.
+     * Listens to entities being loaded and checks if there are any animated blocks among them that need to be
+     * recovered.
+     * <p>
+     * This uses {@link EntitiesLoadEvent} rather than {@link ChunkLoadEvent}: a chunk's entities are not guaranteed to
+     * be loaded yet when the chunk itself loads, and calling {@link Chunk#getEntities()} from within a chunk load
+     * event forces them to load synchronously. On Spigot, that re-enters the chunk system while it is dispatching the
+     * event, which can corrupt its internal state and crash the server.
      *
      * @param event
-     *     The chunk load event to process.
+     *     The entities load event to process.
      */
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onChunkLoadAnimatedBlockRecovery(ChunkLoadEvent event)
+    public void onEntitiesLoadAnimatedBlockRecovery(EntitiesLoadEvent event)
     {
-        for (final Entity entity : event.getChunk().getEntities())
+        for (final Entity entity : event.getEntities())
             animatedBlockHelper.recoverAnimatedBlock(entity);
     }
 

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/EventListeners.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/EventListeners.java
@@ -32,7 +32,6 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -90,7 +89,14 @@ public class EventListeners extends AbstractListener
         if (!animatedArchitectureToolUtil.isPlayerHoldingTool(playerFactory.wrapPlayer(event.getPlayer())))
             return;
 
-        final ExecutorService executorService0 = Objects.requireNonNull(this.executorService);
+        final @Nullable ExecutorService executorService0 = this.executorService;
+        if (executorService0 == null)
+        {
+            // Only possible while this listener is being unregistered; dropping the click is correct then.
+            log.atDebug().log("Ignoring tool click from player %s: listener is shutting down.",
+                event.getPlayer().getName());
+            return;
+        }
 
         toolUserManager
             .getToolUser(event.getPlayer().getUniqueId())
@@ -304,18 +310,32 @@ public class EventListeners extends AbstractListener
     {
         super.unregister();
 
-        final ExecutorService executorService0 = this.executorService;
-        if (executorService0 != null)
+        final @Nullable ExecutorService executorService0 = this.executorService;
+        this.executorService = null;
+        if (executorService0 == null)
+            return;
+
+        // In-flight input handling can block for a while (e.g. on the ToolUser lock), so interrupt
+        // it rather than letting it touch plugin state after the listener has been unregistered.
+        executorService0.shutdownNow();
+        try
         {
-            executorService0.shutdown();
-            this.executorService = null;
+            if (!executorService0.awaitTermination(5, TimeUnit.SECONDS))
+                log.atError().log("Timed out waiting for input-handling tasks to terminate!");
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
         }
     }
 
     @Override
     protected void register()
     {
+        // Create the executor before registering the listener, so that no event can observe a null
+        // executor. Reuse an existing executor to avoid leaking one on repeated registrations.
+        if (this.executorService == null)
+            this.executorService = Executors.newVirtualThreadPerTaskExecutor();
         super.register();
-        this.executorService = Executors.newVirtualThreadPerTaskExecutor();
     }
 }

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/EventListeners.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/EventListeners.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.CustomLog;
 import lombok.experimental.ExtensionMethod;
+import nl.pim16aap2.animatedarchitecture.core.api.ILocation;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
 import nl.pim16aap2.animatedarchitecture.core.managers.DelayedCommandInputManager;
@@ -31,6 +32,10 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,6 +51,8 @@ public class EventListeners extends AbstractListener
     private final DatabaseManager databaseManager;
     private final ToolUserManager toolUserManager;
     private final DelayedCommandInputManager delayedCommandInputManager;
+
+    private volatile @Nullable ExecutorService executorService = null;
 
     @Inject
     EventListeners(
@@ -83,14 +90,19 @@ public class EventListeners extends AbstractListener
         if (!animatedArchitectureToolUtil.isPlayerHoldingTool(playerFactory.wrapPlayer(event.getPlayer())))
             return;
 
+        final ExecutorService executorService0 = Objects.requireNonNull(this.executorService);
+
         toolUserManager
             .getToolUser(event.getPlayer().getUniqueId())
             .ifPresent(toolUser ->
             {
                 event.setCancelled(true);
-                toolUser
-                    .handleInput(SpigotAdapter.wrapLocation(event.getClickedBlock().getLocation()))
-                    .orTimeout(100, TimeUnit.MILLISECONDS)
+
+                final ILocation location = SpigotAdapter.wrapLocation(event.getClickedBlock().getLocation());
+
+                CompletableFuture.completedFuture(null)
+                    .thenComposeAsync(ignored -> toolUser.handleInput(location), executorService0)
+                    .orTimeout(20, TimeUnit.SECONDS)
                     .handleExceptional(e -> log.atError().withCause(e).log(
                         "Failed to handle input for player %s clicking block %s",
                         event.getPlayer().getName(),
@@ -285,5 +297,25 @@ public class EventListeners extends AbstractListener
         {
             log.atError().withCause(e).log("Encountered an error while handling an InventoryMoveItemEvent");
         }
+    }
+
+    @Override
+    protected void unregister()
+    {
+        super.unregister();
+
+        final ExecutorService executorService0 = this.executorService;
+        if (executorService0 != null)
+        {
+            executorService0.shutdown();
+            this.executorService = null;
+        }
+    }
+
+    @Override
+    protected void register()
+    {
+        super.register();
+        this.executorService = Executors.newVirtualThreadPerTaskExecutor();
     }
 }

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -22,10 +22,11 @@
 
         <animatedarchitecture.e2e.serverVersion>latest-supported</animatedarchitecture.e2e.serverVersion>
         <animatedarchitecture.e2e.animatedArchitectureJar>${project.root-dir}/animatedarchitecture-spigot/spigot-packager/target/AnimatedArchitecture-Spigot.jar</animatedarchitecture.e2e.animatedArchitectureJar>
-        <animatedarchitecture.e2e.vaultJar></animatedarchitecture.e2e.vaultJar>
-        <animatedarchitecture.e2e.permissionsJar></animatedarchitecture.e2e.permissionsJar>
-        <animatedarchitecture.e2e.worldguardJar></animatedarchitecture.e2e.worldguardJar>
-        <animatedarchitecture.e2e.worldeditJar></animatedarchitecture.e2e.worldeditJar>
+        <animatedarchitecture.e2e.vaultUrl>https://github.com/MilkBowl/Vault/releases/download/1.7.3/Vault.jar</animatedarchitecture.e2e.vaultUrl>
+        <animatedarchitecture.e2e.vaultSha256>a6b5ed97f43a5cf5bbaf00a7c8cd23c5afc9bd003f849875af8b36e6cf77d01d</animatedarchitecture.e2e.vaultSha256>
+        <animatedarchitecture.e2e.luckPermsVersion>v5.5.17-bukkit</animatedarchitecture.e2e.luckPermsVersion>
+        <animatedarchitecture.e2e.worldEditVersion>7.4.2</animatedarchitecture.e2e.worldEditVersion>
+        <animatedarchitecture.e2e.worldGuardVersion>7.0.15</animatedarchitecture.e2e.worldGuardVersion>
 
         <lightkeeper.paper.runtime-manifest.path>${project.build.directory}/lightkeeper/paper-runtime-manifest.json</lightkeeper.paper.runtime-manifest.path>
         <lightkeeper.spigot.runtime-manifest.path>${project.build.directory}/lightkeeper/spigot-runtime-manifest.json</lightkeeper.spigot.runtime-manifest.path>
@@ -116,49 +117,9 @@
                                         </not>
                                     </or>
                                 </condition>
-                                <condition property="animatedarchitecture.e2e.vaultJar.missing">
-                                    <or>
-                                        <equals arg1="${animatedarchitecture.e2e.vaultJar}" arg2=""/>
-                                        <not>
-                                            <available file="${animatedarchitecture.e2e.vaultJar}" type="file"/>
-                                        </not>
-                                    </or>
-                                </condition>
-                                <condition property="animatedarchitecture.e2e.permissionsJar.missing">
-                                    <or>
-                                        <equals arg1="${animatedarchitecture.e2e.permissionsJar}" arg2=""/>
-                                        <not>
-                                            <available file="${animatedarchitecture.e2e.permissionsJar}" type="file"/>
-                                        </not>
-                                    </or>
-                                </condition>
-                                <condition property="animatedarchitecture.e2e.worldguardJar.missing">
-                                    <or>
-                                        <equals arg1="${animatedarchitecture.e2e.worldguardJar}" arg2=""/>
-                                        <not>
-                                            <available file="${animatedarchitecture.e2e.worldguardJar}" type="file"/>
-                                        </not>
-                                    </or>
-                                </condition>
-                                <condition property="animatedarchitecture.e2e.worldeditJar.missing">
-                                    <or>
-                                        <equals arg1="${animatedarchitecture.e2e.worldeditJar}" arg2=""/>
-                                        <not>
-                                            <available file="${animatedarchitecture.e2e.worldeditJar}" type="file"/>
-                                        </not>
-                                    </or>
-                                </condition>
 
                                 <fail if="animatedarchitecture.e2e.animatedArchitectureJar.missing"
                                       message="AnimatedArchitecture plugin jar was not found at '${animatedarchitecture.e2e.animatedArchitectureJar}'. Run the reactor package phase first."/>
-                                <fail if="animatedarchitecture.e2e.vaultJar.missing"
-                                      message="Set -Danimatedarchitecture.e2e.vaultJar=/path/to/Vault.jar for the LightKeeper e2e profile."/>
-                                <fail if="animatedarchitecture.e2e.permissionsJar.missing"
-                                      message="Set -Danimatedarchitecture.e2e.permissionsJar=/path/to/LuckPerms-Bukkit.jar for the LightKeeper e2e profile."/>
-                                <fail if="animatedarchitecture.e2e.worldguardJar.missing"
-                                      message="Set -Danimatedarchitecture.e2e.worldguardJar=/path/to/worldguard-bukkit.jar for the LightKeeper e2e profile."/>
-                                <fail if="animatedarchitecture.e2e.worldeditJar.missing"
-                                      message="Set -Danimatedarchitecture.e2e.worldeditJar=/path/to/worldedit-bukkit.jar or a compatible FAWE jar for the LightKeeper e2e profile."/>
                             </target>
                         </configuration>
                     </execution>
@@ -174,23 +135,30 @@
                     <configOverlayPath>${project.basedir}/src/test/resources/provisioning/overlay</configOverlayPath>
                     <plugins>
                         <plugin>
-                            <sourceType>path</sourceType>
-                            <path>${animatedarchitecture.e2e.vaultJar}</path>
+                            <sourceType>url</sourceType>
+                            <url>${animatedarchitecture.e2e.vaultUrl}</url>
+                            <sha256>${animatedarchitecture.e2e.vaultSha256}</sha256>
                             <renameTo>Vault.jar</renameTo>
                         </plugin>
                         <plugin>
-                            <sourceType>path</sourceType>
-                            <path>${animatedarchitecture.e2e.permissionsJar}</path>
+                            <sourceType>modrinth</sourceType>
+                            <modrinthProject>luckperms</modrinthProject>
+                            <modrinthVersion>${animatedarchitecture.e2e.luckPermsVersion}</modrinthVersion>
+                            <modrinthLoader>bukkit</modrinthLoader>
                             <renameTo>LuckPerms.jar</renameTo>
                         </plugin>
                         <plugin>
-                            <sourceType>path</sourceType>
-                            <path>${animatedarchitecture.e2e.worldeditJar}</path>
+                            <sourceType>modrinth</sourceType>
+                            <modrinthProject>worldedit</modrinthProject>
+                            <modrinthVersion>${animatedarchitecture.e2e.worldEditVersion}</modrinthVersion>
+                            <modrinthLoader>bukkit</modrinthLoader>
                             <renameTo>WorldEditOrFawe.jar</renameTo>
                         </plugin>
                         <plugin>
-                            <sourceType>path</sourceType>
-                            <path>${animatedarchitecture.e2e.worldguardJar}</path>
+                            <sourceType>modrinth</sourceType>
+                            <modrinthProject>worldguard</modrinthProject>
+                            <modrinthVersion>${animatedarchitecture.e2e.worldGuardVersion}</modrinthVersion>
+                            <modrinthLoader>bukkit</modrinthLoader>
                             <renameTo>WorldGuard.jar</renameTo>
                         </plugin>
                         <plugin>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -37,10 +37,33 @@
 
     <repositories>
         <repository>
+            <id>eldonexus-snapshots</id>
+            <url>https://eldonexus.de/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spigotmc-snapshots</id>
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>eldonexus-snapshots</id>
+            <url>https://eldonexus.de/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -18,7 +18,7 @@
         <project.root-dir>${project.basedir}/../..</project.root-dir>
 
         <version.lightkeeper>1.2.0-SNAPSHOT</version.lightkeeper>
-        <version.spigot-api>1.21.11-R0.2-SNAPSHOT</version.spigot-api>
+        <version.spigot-api>1.21-R0.1-SNAPSHOT</version.spigot-api>
 
         <animatedarchitecture.e2e.serverVersion>latest-supported</animatedarchitecture.e2e.serverVersion>
         <animatedarchitecture.e2e.animatedArchitectureJar>${project.root-dir}/animatedarchitecture-spigot/spigot-packager/target/AnimatedArchitecture-Spigot.jar</animatedarchitecture.e2e.animatedArchitectureJar>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -131,7 +131,7 @@
                 <artifactId>lightkeeper-maven-plugin</artifactId>
                 <version>${version.lightkeeper}</version>
                 <configuration>
-                    <userAgent>AnimatedArchitecture/${project.version} ([email protected])</userAgent>
+                    <userAgent>AnimatedArchitecture/${project.version} (+https://github.com/PimvanderLoos/AnimatedArchitecture)</userAgent>
                     <configOverlayPath>${project.basedir}/src/test/resources/provisioning/overlay</configOverlayPath>
                     <plugins>
                         <plugin>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>animatedarchitecture-lightkeeper-e2e</artifactId>
+    <packaging>jar</packaging>
+    <description>LightKeeper end-to-end tests for AnimatedArchitecture</description>
+
+    <parent>
+        <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+        <artifactId>animatedarchitecture-testing</artifactId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <project.root-dir>${project.basedir}/../..</project.root-dir>
+
+        <version.lightkeeper>1.2.0-SNAPSHOT</version.lightkeeper>
+        <version.spigot-api>1.21.11-R0.2-SNAPSHOT</version.spigot-api>
+
+        <animatedarchitecture.e2e.serverVersion>latest-supported</animatedarchitecture.e2e.serverVersion>
+        <animatedarchitecture.e2e.animatedArchitectureJar>${project.root-dir}/animatedarchitecture-spigot/spigot-packager/target/AnimatedArchitecture-Spigot.jar</animatedarchitecture.e2e.animatedArchitectureJar>
+        <animatedarchitecture.e2e.vaultJar></animatedarchitecture.e2e.vaultJar>
+        <animatedarchitecture.e2e.permissionsJar></animatedarchitecture.e2e.permissionsJar>
+        <animatedarchitecture.e2e.worldguardJar></animatedarchitecture.e2e.worldguardJar>
+        <animatedarchitecture.e2e.worldeditJar></animatedarchitecture.e2e.worldeditJar>
+
+        <lightkeeper.paper.runtime-manifest.path>${project.build.directory}/lightkeeper/paper-runtime-manifest.json</lightkeeper.paper.runtime-manifest.path>
+        <lightkeeper.spigot.runtime-manifest.path>${project.build.directory}/lightkeeper/spigot-runtime-manifest.json</lightkeeper.spigot.runtime-manifest.path>
+        <lightkeeper.paper.server-work-directory>${project.build.directory}/lightkeeper-server/paper</lightkeeper.paper.server-work-directory>
+        <lightkeeper.spigot.server-work-directory>${project.build.directory}/lightkeeper-server/spigot</lightkeeper.spigot.server-work-directory>
+        <lightkeeper.paper.socket-directory>${project.build.directory}/lightkeeper/sockets/paper</lightkeeper.paper.socket-directory>
+        <lightkeeper.spigot.socket-directory>${project.build.directory}/lightkeeper/sockets/spigot</lightkeeper.spigot.socket-directory>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigotmc-snapshots</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>spigot-packager</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.lightkeeper</groupId>
+            <artifactId>lightkeeper-framework-junit</artifactId>
+            <version>${version.lightkeeper}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${version.spigot-api}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${version.maven-antrun}</version>
+                <executions>
+                    <execution>
+                        <id>validate-lightkeeper-e2e-inputs</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <condition property="animatedarchitecture.e2e.animatedArchitectureJar.missing">
+                                    <or>
+                                        <equals arg1="${animatedarchitecture.e2e.animatedArchitectureJar}" arg2=""/>
+                                        <not>
+                                            <available file="${animatedarchitecture.e2e.animatedArchitectureJar}" type="file"/>
+                                        </not>
+                                    </or>
+                                </condition>
+                                <condition property="animatedarchitecture.e2e.vaultJar.missing">
+                                    <or>
+                                        <equals arg1="${animatedarchitecture.e2e.vaultJar}" arg2=""/>
+                                        <not>
+                                            <available file="${animatedarchitecture.e2e.vaultJar}" type="file"/>
+                                        </not>
+                                    </or>
+                                </condition>
+                                <condition property="animatedarchitecture.e2e.permissionsJar.missing">
+                                    <or>
+                                        <equals arg1="${animatedarchitecture.e2e.permissionsJar}" arg2=""/>
+                                        <not>
+                                            <available file="${animatedarchitecture.e2e.permissionsJar}" type="file"/>
+                                        </not>
+                                    </or>
+                                </condition>
+                                <condition property="animatedarchitecture.e2e.worldguardJar.missing">
+                                    <or>
+                                        <equals arg1="${animatedarchitecture.e2e.worldguardJar}" arg2=""/>
+                                        <not>
+                                            <available file="${animatedarchitecture.e2e.worldguardJar}" type="file"/>
+                                        </not>
+                                    </or>
+                                </condition>
+                                <condition property="animatedarchitecture.e2e.worldeditJar.missing">
+                                    <or>
+                                        <equals arg1="${animatedarchitecture.e2e.worldeditJar}" arg2=""/>
+                                        <not>
+                                            <available file="${animatedarchitecture.e2e.worldeditJar}" type="file"/>
+                                        </not>
+                                    </or>
+                                </condition>
+
+                                <fail if="animatedarchitecture.e2e.animatedArchitectureJar.missing"
+                                      message="AnimatedArchitecture plugin jar was not found at '${animatedarchitecture.e2e.animatedArchitectureJar}'. Run the reactor package phase first."/>
+                                <fail if="animatedarchitecture.e2e.vaultJar.missing"
+                                      message="Set -Danimatedarchitecture.e2e.vaultJar=/path/to/Vault.jar for the LightKeeper e2e profile."/>
+                                <fail if="animatedarchitecture.e2e.permissionsJar.missing"
+                                      message="Set -Danimatedarchitecture.e2e.permissionsJar=/path/to/LuckPerms-Bukkit.jar for the LightKeeper e2e profile."/>
+                                <fail if="animatedarchitecture.e2e.worldguardJar.missing"
+                                      message="Set -Danimatedarchitecture.e2e.worldguardJar=/path/to/worldguard-bukkit.jar for the LightKeeper e2e profile."/>
+                                <fail if="animatedarchitecture.e2e.worldeditJar.missing"
+                                      message="Set -Danimatedarchitecture.e2e.worldeditJar=/path/to/worldedit-bukkit.jar or a compatible FAWE jar for the LightKeeper e2e profile."/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>nl.pim16aap2.lightkeeper</groupId>
+                <artifactId>lightkeeper-maven-plugin</artifactId>
+                <version>${version.lightkeeper}</version>
+                <configuration>
+                    <userAgent>AnimatedArchitecture/${project.version} ([email protected])</userAgent>
+                    <configOverlayPath>${project.basedir}/src/test/resources/provisioning/overlay</configOverlayPath>
+                    <plugins>
+                        <plugin>
+                            <sourceType>path</sourceType>
+                            <path>${animatedarchitecture.e2e.vaultJar}</path>
+                            <renameTo>Vault.jar</renameTo>
+                        </plugin>
+                        <plugin>
+                            <sourceType>path</sourceType>
+                            <path>${animatedarchitecture.e2e.permissionsJar}</path>
+                            <renameTo>LuckPerms.jar</renameTo>
+                        </plugin>
+                        <plugin>
+                            <sourceType>path</sourceType>
+                            <path>${animatedarchitecture.e2e.worldeditJar}</path>
+                            <renameTo>WorldEditOrFawe.jar</renameTo>
+                        </plugin>
+                        <plugin>
+                            <sourceType>path</sourceType>
+                            <path>${animatedarchitecture.e2e.worldguardJar}</path>
+                            <renameTo>WorldGuard.jar</renameTo>
+                        </plugin>
+                        <plugin>
+                            <sourceType>path</sourceType>
+                            <path>${animatedarchitecture.e2e.animatedArchitectureJar}</path>
+                            <renameTo>AnimatedArchitecture-Spigot.jar</renameTo>
+                        </plugin>
+                    </plugins>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-server-paper</id>
+                        <goals>
+                            <goal>prepare-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverType>paper</serverType>
+                            <serverVersion>${animatedarchitecture.e2e.serverVersion}</serverVersion>
+                            <runtimeManifestPath>${lightkeeper.paper.runtime-manifest.path}</runtimeManifestPath>
+                            <serverWorkDirectoryRoot>${lightkeeper.paper.server-work-directory}</serverWorkDirectoryRoot>
+                            <agentSocketDirectory>${lightkeeper.paper.socket-directory}</agentSocketDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-server-spigot</id>
+                        <goals>
+                            <goal>prepare-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverType>spigot</serverType>
+                            <serverVersion>${animatedarchitecture.e2e.serverVersion}</serverVersion>
+                            <runtimeManifestPath>${lightkeeper.spigot.runtime-manifest.path}</runtimeManifestPath>
+                            <serverWorkDirectoryRoot>${lightkeeper.spigot.server-work-directory}</serverWorkDirectoryRoot>
+                            <agentSocketDirectory>${lightkeeper.spigot.socket-directory}</agentSocketDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cleanup-server-paper</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>cleanup-server</goal>
+                        </goals>
+                        <configuration>
+                            <failsafeSummaryPath>${project.build.directory}/failsafe-reports/paper/failsafe-summary.xml</failsafeSummaryPath>
+                            <serverWorkDirectoryRoot>${lightkeeper.paper.server-work-directory}</serverWorkDirectoryRoot>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cleanup-server-spigot</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>cleanup-server</goal>
+                        </goals>
+                        <configuration>
+                            <failsafeSummaryPath>${project.build.directory}/failsafe-reports/spigot/failsafe-summary.xml</failsafeSummaryPath>
+                            <serverWorkDirectoryRoot>${lightkeeper.spigot.server-work-directory}</serverWorkDirectoryRoot>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${version.failsafe}</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <trimStackTrace>false</trimStackTrace>
+                    <useFile>false</useFile>
+                    <systemPropertyVariables>
+                        <flogger.backend_factory>com.google.common.flogger.backend.slf4j.Slf4jBackendFactory#getInstance</flogger.backend_factory>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-paper</id>
+                        <configuration>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/paper</reportsDirectory>
+                            <summaryFile>${project.build.directory}/failsafe-reports/paper/failsafe-summary.xml</summaryFile>
+                            <systemPropertyVariables>
+                                <lightkeeper.runtimeManifestPath>${lightkeeper.paper.runtime-manifest.path}</lightkeeper.runtimeManifestPath>
+                                <animatedarchitecture.e2e.serverType>paper</animatedarchitecture.e2e.serverType>
+                                <flogger.backend_factory>com.google.common.flogger.backend.slf4j.Slf4jBackendFactory#getInstance</flogger.backend_factory>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>integration-spigot</id>
+                        <configuration>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/spigot</reportsDirectory>
+                            <summaryFile>${project.build.directory}/failsafe-reports/spigot/failsafe-summary.xml</summaryFile>
+                            <systemPropertyVariables>
+                                <lightkeeper.runtimeManifestPath>${lightkeeper.spigot.runtime-manifest.path}</lightkeeper.runtimeManifestPath>
+                                <animatedarchitecture.e2e.serverType>spigot</animatedarchitecture.e2e.serverType>
+                                <flogger.backend_factory>com.google.common.flogger.backend.slf4j.Slf4jBackendFactory#getInstance</flogger.backend_factory>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -19,6 +19,7 @@
 
         <version.lightkeeper>1.2.0-SNAPSHOT</version.lightkeeper>
         <version.spigot-api>1.21-R0.1-SNAPSHOT</version.spigot-api>
+        <version.jspecify>1.0.0</version.jspecify>
 
         <animatedarchitecture.e2e.serverVersion>latest-supported</animatedarchitecture.e2e.serverVersion>
         <animatedarchitecture.e2e.animatedArchitectureJar>${project.root-dir}/animatedarchitecture-spigot/spigot-packager/target/AnimatedArchitecture-Spigot.jar</animatedarchitecture.e2e.animatedArchitectureJar>
@@ -83,6 +84,15 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${version.spigot-api}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Used directly (@NullMarked in package-info); declared explicitly instead of
+             relying on the transitive dependency from lightkeeper-framework-junit. -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${version.jspecify}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/pom.xml
@@ -32,8 +32,6 @@
         <lightkeeper.spigot.runtime-manifest.path>${project.build.directory}/lightkeeper/spigot-runtime-manifest.json</lightkeeper.spigot.runtime-manifest.path>
         <lightkeeper.paper.server-work-directory>${project.build.directory}/lightkeeper-server/paper</lightkeeper.paper.server-work-directory>
         <lightkeeper.spigot.server-work-directory>${project.build.directory}/lightkeeper-server/spigot</lightkeeper.spigot.server-work-directory>
-        <lightkeeper.paper.socket-directory>${project.build.directory}/lightkeeper/sockets/paper</lightkeeper.paper.socket-directory>
-        <lightkeeper.spigot.socket-directory>${project.build.directory}/lightkeeper/sockets/spigot</lightkeeper.spigot.socket-directory>
     </properties>
 
     <repositories>
@@ -179,7 +177,6 @@
                             <serverVersion>${animatedarchitecture.e2e.serverVersion}</serverVersion>
                             <runtimeManifestPath>${lightkeeper.paper.runtime-manifest.path}</runtimeManifestPath>
                             <serverWorkDirectoryRoot>${lightkeeper.paper.server-work-directory}</serverWorkDirectoryRoot>
-                            <agentSocketDirectory>${lightkeeper.paper.socket-directory}</agentSocketDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -192,7 +189,6 @@
                             <serverVersion>${animatedarchitecture.e2e.serverVersion}</serverVersion>
                             <runtimeManifestPath>${lightkeeper.spigot.runtime-manifest.path}</runtimeManifestPath>
                             <serverWorkDirectoryRoot>${lightkeeper.spigot.server-work-directory}</serverWorkDirectoryRoot>
-                            <agentSocketDirectory>${lightkeeper.spigot.socket-directory}</agentSocketDirectory>
                         </configuration>
                     </execution>
                     <execution>

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
@@ -1,7 +1,5 @@
 package nl.pim16aap2.animatedarchitecture.lightkeeper.e2e;
 
-import nl.pim16aap2.lightkeeper.framework.CommandResult;
-import nl.pim16aap2.lightkeeper.framework.CommandSource;
 import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
@@ -10,6 +8,7 @@ import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
@@ -42,8 +41,8 @@ final class AnimatedArchitectureE2eSupport
         final PlayerHandle player = framework.buildPlayer()
             .withName(name)
             .atLocation(world, location.x(), location.y(), location.z())
+            .withPermissions(ANIMATED_ARCHITECTURE_USER_PERMISSIONS)
             .build();
-        grantPermissions(framework, name, ANIMATED_ARCHITECTURE_USER_PERMISSIONS);
         player.andWaitTicks(10);
         return player;
     }
@@ -53,6 +52,13 @@ final class AnimatedArchitectureE2eSupport
         final String serverType = System.getProperty("animatedarchitecture.e2e.serverType", "server");
         final String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         return prefix + "_" + serverType + "_" + suffix;
+    }
+
+    static String uniquePlayerName(String prefix)
+    {
+        final String serverType = System.getProperty("animatedarchitecture.e2e.serverType", "server");
+        final String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return prefix + "_" + serverType.charAt(0) + "_" + suffix;
     }
 
     static void placePortcullisFixture(WorldHandle world, Vector3Di lowerBlock)
@@ -151,22 +157,13 @@ final class AnimatedArchitectureE2eSupport
 
     static void assertServerHealthy(ILightkeeperFramework framework)
     {
-        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(framework)
-            .hasNoServerErrors();
-    }
-
-    private static void grantPermissions(ILightkeeperFramework framework, String playerName, String... permissions)
-    {
-        for (final String permission : permissions)
-            executeConsole(framework, "lp user " + playerName + " permission set " + permission + " true");
-    }
-
-    private static void executeConsole(ILightkeeperFramework framework, String command)
-    {
-        final CommandResult result = framework.executeCommand(CommandSource.CONSOLE, command);
-        assertThat(result.success())
-            .as(result.message())
-            .isTrue();
+        final List<String> unexpectedErrorLines = framework.serverOutput()
+            .stream()
+            .filter(AnimatedArchitectureE2eSupport::isUnexpectedServerErrorLine)
+            .toList();
+        assertThat(unexpectedErrorLines)
+            .as("server output should not contain unexpected error lines")
+            .isEmpty();
     }
 
     private static String normalizedDisplayName(MenuItemSnapshot item)
@@ -180,5 +177,20 @@ final class AnimatedArchitectureE2eSupport
     {
         final String normalized = material.trim().toLowerCase(Locale.ROOT);
         return normalized.startsWith("minecraft:") ? normalized : "minecraft:" + normalized;
+    }
+
+    private static boolean isUnexpectedServerErrorLine(String line)
+    {
+        if (line.contains("Encountered error creating block state from block data")
+            && line.contains("minecraft:moving_piston"))
+        {
+            return false;
+        }
+
+        final String normalized = line.toLowerCase(Locale.ROOT);
+        return normalized.contains("severe")
+            || normalized.contains("[error]")
+            || normalized.contains("exception")
+            || normalized.contains("caused by:");
     }
 }

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
@@ -38,7 +38,7 @@ final class AnimatedArchitectureE2eSupport
         String name,
         Vector3Di location)
     {
-        final PlayerHandle player = framework.buildPlayer()
+        final PlayerHandle player = framework.bots().builder()
             .withName(name)
             .atLocation(world, location.x(), location.y(), location.z())
             .withPermissions(ANIMATED_ARCHITECTURE_USER_PERMISSIONS)
@@ -84,13 +84,13 @@ final class AnimatedArchitectureE2eSupport
         Vector3Di lowerBlock,
         int blocksToMove)
     {
+        player.leftClickBlock(lowerBlock);
+        player.andWaitTicks(5);
+        player.leftClickBlock(offset(lowerBlock, 0, 1, 0));
+        player.andWaitTicks(5);
+        player.leftClickBlock(offset(lowerBlock, 0, -1, 0));
+        player.andWaitTicks(5);
         player
-            .leftClickBlock(lowerBlock)
-            .andWaitTicks(5)
-            .leftClickBlock(offset(lowerBlock, 0, 1, 0))
-            .andWaitTicks(5)
-            .leftClickBlock(offset(lowerBlock, 0, -1, 0))
-            .andWaitTicks(5)
             .executeCommand("aa setopenstatus Closed")
             .andWaitTicks(5)
             .executeCommand("aa setopendirection Up")
@@ -171,7 +171,7 @@ final class AnimatedArchitectureE2eSupport
 
     static void assertServerHealthy(ILightkeeperFramework framework)
     {
-        final List<String> unexpectedErrorLines = framework.serverOutput()
+        final List<String> unexpectedErrorLines = framework.server().output()
             .stream()
             .filter(AnimatedArchitectureE2eSupport::isUnexpectedServerErrorLine)
             .toList();

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
@@ -1,0 +1,184 @@
+package nl.pim16aap2.animatedarchitecture.lightkeeper.e2e;
+
+import nl.pim16aap2.lightkeeper.framework.CommandResult;
+import nl.pim16aap2.lightkeeper.framework.CommandSource;
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.MenuHandle;
+import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
+import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
+import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class AnimatedArchitectureE2eSupport
+{
+    private static final Pattern COLOR_CODE_PATTERN = Pattern.compile("(?i)\u00a7[0-9A-FK-ORX]");
+    private static final Duration DEFAULT_WAIT_TIMEOUT = Duration.ofSeconds(20);
+    private static final String[] ANIMATED_ARCHITECTURE_USER_PERMISSIONS = {
+        "animatedarchitecture.user.base",
+        "animatedarchitecture.user.create.portcullis",
+        "animatedarchitecture.user.info",
+        "animatedarchitecture.user.liststructures",
+        "animatedarchitecture.user.toggle"
+    };
+
+    private AnimatedArchitectureE2eSupport()
+    {
+    }
+
+    static PlayerHandle createAnimatedArchitecturePlayer(
+        ILightkeeperFramework framework,
+        WorldHandle world,
+        String name,
+        Vector3Di location)
+    {
+        final PlayerHandle player = framework.buildPlayer()
+            .withName(name)
+            .atLocation(world, location.x(), location.y(), location.z())
+            .build();
+        grantPermissions(framework, name, ANIMATED_ARCHITECTURE_USER_PERMISSIONS);
+        player.andWaitTicks(10);
+        return player;
+    }
+
+    static String uniqueName(String prefix)
+    {
+        final String serverType = System.getProperty("animatedarchitecture.e2e.serverType", "server");
+        final String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return prefix + "_" + serverType + "_" + suffix;
+    }
+
+    static void placePortcullisFixture(WorldHandle world, Vector3Di lowerBlock)
+    {
+        world.setBlockAt(lowerBlock, "minecraft:stone");
+        world.setBlockAt(offset(lowerBlock, 0, 1, 0), "minecraft:stone");
+        world.setBlockAt(offset(lowerBlock, 0, -1, 0), "minecraft:gold_block");
+    }
+
+    static void createClosedUpwardPortcullis(
+        PlayerHandle player,
+        String structureName,
+        Vector3Di lowerBlock,
+        int blocksToMove)
+    {
+        player.executeCommand("aa newstructure portcullis " + structureName)
+            .andWaitTicks(5);
+        completeActivePortcullisCreator(player, lowerBlock, blocksToMove);
+    }
+
+    static void completeActivePortcullisCreator(
+        PlayerHandle player,
+        Vector3Di lowerBlock,
+        int blocksToMove)
+    {
+        player
+            .leftClickBlock(lowerBlock)
+            .andWaitTicks(5)
+            .leftClickBlock(offset(lowerBlock, 0, 1, 0))
+            .andWaitTicks(5)
+            .leftClickBlock(offset(lowerBlock, 0, -1, 0))
+            .andWaitTicks(5)
+            .executeCommand("aa setopenstatus Closed")
+            .andWaitTicks(5)
+            .executeCommand("aa setopendirection Up")
+            .andWaitTicks(5)
+            .executeCommand("aa setblockstomove " + blocksToMove)
+            .andWaitTicks(5)
+            .executeCommand("aa confirm")
+            .andWaitTicks(20);
+    }
+
+    static void setCreatorName(PlayerHandle player, String structureName)
+    {
+        player.executeCommand("aa setname " + structureName)
+            .andWaitTicks(5);
+    }
+
+    static void toggleAndWaitForOpen(
+        ILightkeeperFramework framework,
+        PlayerHandle player,
+        WorldHandle world,
+        String structureName,
+        Vector3Di lowerBlock,
+        int blocksToMove)
+    {
+        player.executeCommand("aa toggle " + structureName)
+            .andWaitTicks(5);
+        waitForBlock(framework, world, offset(lowerBlock, 0, blocksToMove, 0), "minecraft:stone");
+        waitForBlock(framework, world, offset(lowerBlock, 0, blocksToMove + 1, 0), "minecraft:stone");
+        waitForBlock(framework, world, lowerBlock, "minecraft:air");
+        waitForBlock(framework, world, offset(lowerBlock, 0, 1, 0), "minecraft:air");
+    }
+
+    static Vector3Di offset(Vector3Di vector, int x, int y, int z)
+    {
+        return new Vector3Di(vector.x() + x, vector.y() + y, vector.z() + z);
+    }
+
+    static void waitForBlock(
+        ILightkeeperFramework framework,
+        WorldHandle world,
+        Vector3Di position,
+        String expectedMaterial)
+    {
+        framework.waitUntil(
+            () -> normalizeMaterial(world.blockTypeAt(position)).equals(normalizeMaterial(expectedMaterial)),
+            DEFAULT_WAIT_TIMEOUT
+        );
+    }
+
+    static MenuHandle clickMenuItemContaining(MenuHandle menu, String expectedDisplayName)
+    {
+        final int slot = menu.snapshot()
+            .items()
+            .stream()
+            .filter(item -> normalizedDisplayName(item).contains(expectedDisplayName))
+            .mapToInt(MenuItemSnapshot::slot)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "Could not find menu item containing '%s' in menu '%s'."
+                    .formatted(expectedDisplayName, menu.snapshot().title())
+            ));
+        return menu.clickAtIndex(slot);
+    }
+
+    static void assertServerHealthy(ILightkeeperFramework framework)
+    {
+        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(framework)
+            .hasNoServerErrors();
+    }
+
+    private static void grantPermissions(ILightkeeperFramework framework, String playerName, String... permissions)
+    {
+        for (final String permission : permissions)
+            executeConsole(framework, "lp user " + playerName + " permission set " + permission + " true");
+    }
+
+    private static void executeConsole(ILightkeeperFramework framework, String command)
+    {
+        final CommandResult result = framework.executeCommand(CommandSource.CONSOLE, command);
+        assertThat(result.success())
+            .as(result.message())
+            .isTrue();
+    }
+
+    private static String normalizedDisplayName(MenuItemSnapshot item)
+    {
+        return COLOR_CODE_PATTERN
+            .matcher(Objects.requireNonNullElse(item.displayName(), ""))
+            .replaceAll("");
+    }
+
+    private static String normalizeMaterial(String material)
+    {
+        final String normalized = material.trim().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("minecraft:") ? normalized : "minecraft:" + normalized;
+    }
+}

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
@@ -4,7 +4,7 @@ import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.MenuItemSnapshot;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 
 import java.time.Duration;
@@ -36,7 +36,7 @@ final class AnimatedArchitectureE2eSupport
         ILightkeeperFramework framework,
         WorldHandle world,
         String name,
-        Vector3Di location)
+        BlockPos location)
     {
         final PlayerHandle player = framework.bots().builder()
             .withName(name)
@@ -61,7 +61,7 @@ final class AnimatedArchitectureE2eSupport
         return prefix + "_" + serverType.charAt(0) + "_" + suffix;
     }
 
-    static void placePortcullisFixture(WorldHandle world, Vector3Di lowerBlock)
+    static void placePortcullisFixture(WorldHandle world, BlockPos lowerBlock)
     {
         world.setBlockAt(lowerBlock, "minecraft:stone");
         world.setBlockAt(offset(lowerBlock, 0, 1, 0), "minecraft:stone");
@@ -71,7 +71,7 @@ final class AnimatedArchitectureE2eSupport
     static void createClosedUpwardPortcullis(
         PlayerHandle player,
         String structureName,
-        Vector3Di lowerBlock,
+        BlockPos lowerBlock,
         int blocksToMove)
     {
         player.executeCommand("aa newstructure portcullis " + structureName)
@@ -81,7 +81,7 @@ final class AnimatedArchitectureE2eSupport
 
     static void completeActivePortcullisCreator(
         PlayerHandle player,
-        Vector3Di lowerBlock,
+        BlockPos lowerBlock,
         int blocksToMove)
     {
         player.leftClickBlock(lowerBlock);
@@ -112,7 +112,7 @@ final class AnimatedArchitectureE2eSupport
         PlayerHandle player,
         WorldHandle world,
         String structureName,
-        Vector3Di lowerBlock,
+        BlockPos lowerBlock,
         int blocksToMove)
     {
         player.executeCommand("aa toggle " + structureName)
@@ -123,15 +123,15 @@ final class AnimatedArchitectureE2eSupport
         waitForBlock(framework, world, offset(lowerBlock, 0, 1, 0), "minecraft:air");
     }
 
-    static Vector3Di offset(Vector3Di vector, int x, int y, int z)
+    static BlockPos offset(BlockPos vector, int x, int y, int z)
     {
-        return new Vector3Di(vector.x() + x, vector.y() + y, vector.z() + z);
+        return new BlockPos(vector.x() + x, vector.y() + y, vector.z() + z);
     }
 
     static void waitForBlock(
         ILightkeeperFramework framework,
         WorldHandle world,
-        Vector3Di position,
+        BlockPos position,
         String expectedMaterial)
     {
         final String expected = normalizeMaterial(expectedMaterial);

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureE2eSupport.java
@@ -134,10 +134,24 @@ final class AnimatedArchitectureE2eSupport
         Vector3Di position,
         String expectedMaterial)
     {
-        framework.waitUntil(
-            () -> normalizeMaterial(world.blockTypeAt(position)).equals(normalizeMaterial(expectedMaterial)),
-            DEFAULT_WAIT_TIMEOUT
-        );
+        final String expected = normalizeMaterial(expectedMaterial);
+        try
+        {
+            framework.waitUntil(
+                () -> normalizeMaterial(world.blockTypeAt(position)).equals(expected),
+                DEFAULT_WAIT_TIMEOUT
+            );
+        }
+        catch (IllegalStateException exception)
+        {
+            final String actual = normalizeMaterial(world.blockTypeAt(position));
+            final String serverType = System.getProperty("animatedarchitecture.e2e.serverType", "unknown");
+            throw new IllegalStateException(
+                "Timed out waiting for block at %s in world '%s' on %s. Expected '%s', found '%s'."
+                    .formatted(position, world.name(), serverType, expected, actual),
+                exception
+            );
+        }
     }
 
     static MenuHandle clickMenuItemContaining(MenuHandle menu, String expectedDisplayName)

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -28,7 +28,7 @@ class AnimatedArchitectureLightkeeperIT
     void portcullisCommandFlow_shouldCreateToggleAndMoveBlocks(ILightkeeperFramework framework)
     {
         // setup
-        final WorldHandle world = framework.mainWorld();
+        final WorldHandle world = framework.worlds().main();
         final Vector3Di lowerBlock = new Vector3Di(10, 100, 10);
         final String structureName = AnimatedArchitectureE2eSupport.uniqueName("cmd_portcullis");
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
@@ -69,7 +69,7 @@ class AnimatedArchitectureLightkeeperIT
     void createStructureMenu_shouldStartCreatorAndCreatePortcullis(ILightkeeperFramework framework)
     {
         // setup
-        final WorldHandle world = framework.mainWorld();
+        final WorldHandle world = framework.worlds().main();
         final Vector3Di lowerBlock = new Vector3Di(20, 100, 10);
         final String structureName = AnimatedArchitectureE2eSupport.uniqueName("gui_portcullis");
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
@@ -114,7 +114,7 @@ class AnimatedArchitectureLightkeeperIT
         ILightkeeperFramework framework)
     {
         // setup
-        final WorldHandle world = framework.mainWorld();
+        final WorldHandle world = framework.worlds().main();
         final Vector3Di deniedLowerBlock = new Vector3Di(42, 100, 42);
         final Vector3Di allowedLowerBlock = new Vector3Di(60, 100, 42);
         final String deniedStructureName = AnimatedArchitectureE2eSupport.uniqueName("wg_denied");
@@ -130,9 +130,9 @@ class AnimatedArchitectureLightkeeperIT
 
         // execute
         player.executeCommand("aa newstructure portcullis " + deniedStructureName)
-            .andWaitTicks(5)
-            .leftClickBlock(deniedLowerBlock)
-            .andWaitTicks(10);
+            .andWaitTicks(5);
+        player.leftClickBlock(deniedLowerBlock);
+        player.andWaitTicks(10);
         player.executeCommand("aa cancel")
             .andWaitTicks(5);
         AnimatedArchitectureE2eSupport.createClosedUpwardPortcullis(

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -4,7 +4,7 @@ import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
 import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
 import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
-import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.BlockPos;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
 import nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -29,13 +29,13 @@ class AnimatedArchitectureLightkeeperIT
     {
         // setup
         final WorldHandle world = framework.worlds().main();
-        final Vector3Di lowerBlock = new Vector3Di(10, 100, 10);
+        final BlockPos lowerBlock = new BlockPos(10, 100, 10);
         final String structureName = AnimatedArchitectureE2eSupport.uniqueName("cmd_portcullis");
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
             AnimatedArchitectureE2eSupport.uniquePlayerName("cmd"),
-            new Vector3Di(10, 100, 8)
+            new BlockPos(10, 100, 8)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
 
@@ -70,13 +70,13 @@ class AnimatedArchitectureLightkeeperIT
     {
         // setup
         final WorldHandle world = framework.worlds().main();
-        final Vector3Di lowerBlock = new Vector3Di(20, 100, 10);
+        final BlockPos lowerBlock = new BlockPos(20, 100, 10);
         final String structureName = AnimatedArchitectureE2eSupport.uniqueName("gui_portcullis");
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
             AnimatedArchitectureE2eSupport.uniquePlayerName("gui"),
-            new Vector3Di(20, 100, 8)
+            new BlockPos(20, 100, 8)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
 
@@ -115,15 +115,15 @@ class AnimatedArchitectureLightkeeperIT
     {
         // setup
         final WorldHandle world = framework.worlds().main();
-        final Vector3Di deniedLowerBlock = new Vector3Di(42, 100, 42);
-        final Vector3Di allowedLowerBlock = new Vector3Di(60, 100, 42);
+        final BlockPos deniedLowerBlock = new BlockPos(42, 100, 42);
+        final BlockPos allowedLowerBlock = new BlockPos(60, 100, 42);
         final String deniedStructureName = AnimatedArchitectureE2eSupport.uniqueName("wg_denied");
         final String allowedStructureName = AnimatedArchitectureE2eSupport.uniqueName("wg_allowed");
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
             AnimatedArchitectureE2eSupport.uniquePlayerName("wg"),
-            new Vector3Di(40, 100, 39)
+            new BlockPos(40, 100, 39)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, deniedLowerBlock);
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, allowedLowerBlock);

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -6,6 +6,7 @@ import nl.pim16aap2.lightkeeper.framework.MenuHandle;
 import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
 import nl.pim16aap2.lightkeeper.framework.Vector3Di;
 import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+import nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,10 +56,10 @@ class AnimatedArchitectureLightkeeperIT
         );
 
         // verify
-        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+        LightkeeperAssertions.assertThat(world)
             .hasBlockAt(lowerBlock)
             .ofType("minecraft:air");
-        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+        LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE, 0))
             .ofType("minecraft:stone");
         assertThat(player.receivedMessagesText()).contains("Portcullis creation successful");
@@ -102,7 +103,7 @@ class AnimatedArchitectureLightkeeperIT
         );
 
         // verify
-        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+        LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE + 1, 0))
             .ofType("minecraft:stone");
         assertThat(player.receivedMessagesText()).contains("Portcullis creation successful");
@@ -151,7 +152,7 @@ class AnimatedArchitectureLightkeeperIT
 
         // verify
         assertThat(player.receivedMessagesText()).contains("not allowed to create structures in this region");
-        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+        LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(allowedLowerBlock, 0, BLOCKS_TO_MOVE, 0))
             .ofType("minecraft:stone");
     }

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -61,7 +61,7 @@ class AnimatedArchitectureLightkeeperIT
         nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE, 0))
             .ofType("minecraft:stone");
-        assertThat(player.receivedMessagesText()).contains("structure.type.portcullis creation successful");
+        assertThat(player.receivedMessagesText()).contains("Portcullis creation successful");
     }
 
     @Test
@@ -105,7 +105,7 @@ class AnimatedArchitectureLightkeeperIT
         nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE + 1, 0))
             .ofType("minecraft:stone");
-        assertThat(player.receivedMessagesText()).contains("creation successful");
+        assertThat(player.receivedMessagesText()).contains("Portcullis creation successful");
     }
 
     @Test

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -33,7 +33,7 @@ class AnimatedArchitectureLightkeeperIT
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
-            AnimatedArchitectureE2eSupport.uniqueName("cmd_player"),
+            AnimatedArchitectureE2eSupport.uniquePlayerName("cmd"),
             new Vector3Di(10, 100, 8)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
@@ -61,7 +61,7 @@ class AnimatedArchitectureLightkeeperIT
         nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
             .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE, 0))
             .ofType("minecraft:stone");
-        assertThat(player.receivedMessagesText()).contains("Portcullis");
+        assertThat(player.receivedMessagesText()).contains("structure.type.portcullis creation successful");
     }
 
     @Test
@@ -74,7 +74,7 @@ class AnimatedArchitectureLightkeeperIT
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
-            AnimatedArchitectureE2eSupport.uniqueName("gui_player"),
+            AnimatedArchitectureE2eSupport.uniquePlayerName("gui"),
             new Vector3Di(20, 100, 8)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
@@ -121,7 +121,7 @@ class AnimatedArchitectureLightkeeperIT
         final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
             framework,
             world,
-            AnimatedArchitectureE2eSupport.uniqueName("wg_player"),
+            AnimatedArchitectureE2eSupport.uniquePlayerName("wg"),
             new Vector3Di(40, 100, 39)
         );
         AnimatedArchitectureE2eSupport.placePortcullisFixture(world, deniedLowerBlock);

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/AnimatedArchitectureLightkeeperIT.java
@@ -1,0 +1,158 @@
+package nl.pim16aap2.animatedarchitecture.lightkeeper.e2e;
+
+import nl.pim16aap2.lightkeeper.framework.ILightkeeperFramework;
+import nl.pim16aap2.lightkeeper.framework.LightkeeperExtension;
+import nl.pim16aap2.lightkeeper.framework.MenuHandle;
+import nl.pim16aap2.lightkeeper.framework.PlayerHandle;
+import nl.pim16aap2.lightkeeper.framework.Vector3Di;
+import nl.pim16aap2.lightkeeper.framework.WorldHandle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(LightkeeperExtension.class)
+class AnimatedArchitectureLightkeeperIT
+{
+    private static final int BLOCKS_TO_MOVE = 2;
+
+    @AfterEach
+    void assertServerOutput_shouldContainNoUnexpectedErrors(ILightkeeperFramework framework)
+    {
+        AnimatedArchitectureE2eSupport.assertServerHealthy(framework);
+    }
+
+    @Test
+    void portcullisCommandFlow_shouldCreateToggleAndMoveBlocks(ILightkeeperFramework framework)
+    {
+        // setup
+        final WorldHandle world = framework.mainWorld();
+        final Vector3Di lowerBlock = new Vector3Di(10, 100, 10);
+        final String structureName = AnimatedArchitectureE2eSupport.uniqueName("cmd_portcullis");
+        final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
+            framework,
+            world,
+            AnimatedArchitectureE2eSupport.uniqueName("cmd_player"),
+            new Vector3Di(10, 100, 8)
+        );
+        AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
+
+        // execute
+        AnimatedArchitectureE2eSupport.createClosedUpwardPortcullis(
+            player,
+            structureName,
+            lowerBlock,
+            BLOCKS_TO_MOVE
+        );
+        AnimatedArchitectureE2eSupport.toggleAndWaitForOpen(
+            framework,
+            player,
+            world,
+            structureName,
+            lowerBlock,
+            BLOCKS_TO_MOVE
+        );
+
+        // verify
+        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+            .hasBlockAt(lowerBlock)
+            .ofType("minecraft:air");
+        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+            .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE, 0))
+            .ofType("minecraft:stone");
+        assertThat(player.receivedMessagesText()).contains("Portcullis");
+    }
+
+    @Test
+    void createStructureMenu_shouldStartCreatorAndCreatePortcullis(ILightkeeperFramework framework)
+    {
+        // setup
+        final WorldHandle world = framework.mainWorld();
+        final Vector3Di lowerBlock = new Vector3Di(20, 100, 10);
+        final String structureName = AnimatedArchitectureE2eSupport.uniqueName("gui_portcullis");
+        final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
+            framework,
+            world,
+            AnimatedArchitectureE2eSupport.uniqueName("gui_player"),
+            new Vector3Di(20, 100, 8)
+        );
+        AnimatedArchitectureE2eSupport.placePortcullisFixture(world, lowerBlock);
+
+        // execute
+        final MenuHandle mainMenu = player.executeCommand("aa menu")
+            .andWaitForMenuOpen(10)
+            .verifyMenuName("AnimatedArchitecture Menu");
+        AnimatedArchitectureE2eSupport.clickMenuItemContaining(mainMenu, "Create a new structure")
+            .andWaitTicks(5);
+        final MenuHandle createMenu = player.andWaitForMenuOpen(10)
+            .verifyMenuName("New Structure");
+        AnimatedArchitectureE2eSupport.clickMenuItemContaining(createMenu, "Create a new Portcullis")
+            .andWaitForMenuClose()
+            .verifyMenuClosed();
+        AnimatedArchitectureE2eSupport.setCreatorName(player, structureName);
+        AnimatedArchitectureE2eSupport.completeActivePortcullisCreator(player, lowerBlock, BLOCKS_TO_MOVE);
+        AnimatedArchitectureE2eSupport.toggleAndWaitForOpen(
+            framework,
+            player,
+            world,
+            structureName,
+            lowerBlock,
+            BLOCKS_TO_MOVE
+        );
+
+        // verify
+        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+            .hasBlockAt(AnimatedArchitectureE2eSupport.offset(lowerBlock, 0, BLOCKS_TO_MOVE + 1, 0))
+            .ofType("minecraft:stone");
+        assertThat(player.receivedMessagesText()).contains("creation successful");
+    }
+
+    @Test
+    void worldGuardProtection_shouldDenyCreationInsideProtectedRegionAndAllowCreationOutside(
+        ILightkeeperFramework framework)
+    {
+        // setup
+        final WorldHandle world = framework.mainWorld();
+        final Vector3Di deniedLowerBlock = new Vector3Di(42, 100, 42);
+        final Vector3Di allowedLowerBlock = new Vector3Di(60, 100, 42);
+        final String deniedStructureName = AnimatedArchitectureE2eSupport.uniqueName("wg_denied");
+        final String allowedStructureName = AnimatedArchitectureE2eSupport.uniqueName("wg_allowed");
+        final PlayerHandle player = AnimatedArchitectureE2eSupport.createAnimatedArchitecturePlayer(
+            framework,
+            world,
+            AnimatedArchitectureE2eSupport.uniqueName("wg_player"),
+            new Vector3Di(40, 100, 39)
+        );
+        AnimatedArchitectureE2eSupport.placePortcullisFixture(world, deniedLowerBlock);
+        AnimatedArchitectureE2eSupport.placePortcullisFixture(world, allowedLowerBlock);
+
+        // execute
+        player.executeCommand("aa newstructure portcullis " + deniedStructureName)
+            .andWaitTicks(5)
+            .leftClickBlock(deniedLowerBlock)
+            .andWaitTicks(10);
+        player.executeCommand("aa cancel")
+            .andWaitTicks(5);
+        AnimatedArchitectureE2eSupport.createClosedUpwardPortcullis(
+            player,
+            allowedStructureName,
+            allowedLowerBlock,
+            BLOCKS_TO_MOVE
+        );
+        AnimatedArchitectureE2eSupport.toggleAndWaitForOpen(
+            framework,
+            player,
+            world,
+            allowedStructureName,
+            allowedLowerBlock,
+            BLOCKS_TO_MOVE
+        );
+
+        // verify
+        assertThat(player.receivedMessagesText()).contains("not allowed to create structures in this region");
+        nl.pim16aap2.lightkeeper.framework.assertions.LightkeeperAssertions.assertThat(world)
+            .hasBlockAt(AnimatedArchitectureE2eSupport.offset(allowedLowerBlock, 0, BLOCKS_TO_MOVE, 0))
+            .ofType("minecraft:stone");
+    }
+}

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/package-info.java
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/java/nl/pim16aap2/animatedarchitecture/lightkeeper/e2e/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * End-to-end tests that run AnimatedArchitecture on real Paper and Spigot servers through LightKeeper.
+ * <p>
+ * The package provisions the final AnimatedArchitecture Spigot plugin together with Vault, a permissions provider,
+ * WorldEdit or FAWE, and WorldGuard. Tests then drive synthetic players through real commands, inventory menus, block
+ * clicks, and protection checks.
+ */
+@org.jspecify.annotations.NullMarked
+package nl.pim16aap2.animatedarchitecture.lightkeeper.e2e;

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/AnimatedArchitecture/config.yaml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/AnimatedArchitecture/config.yaml
@@ -1,0 +1,22 @@
+version: 0
+general:
+  resource_pack_enabled: false
+  material_blacklist: []
+  command_aliases:
+    - aa
+    - animatedarchitecture
+    - AnimatedArchitecture
+redstone:
+  allow_redstone: false
+animations:
+  load_chunks_for_toggle: true
+  skip_animations_by_default: true
+limits:
+  max_structure_count: -1
+  max_structure_size: 1000
+  max_blocks_to_move: 100
+  max_powerblock_distance: -1
+  max_block_speed: 100.0
+protection_hooks:
+  WorldGuard:
+    enabled: true

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/AnimatedArchitecture/config.yaml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/AnimatedArchitecture/config.yaml
@@ -8,6 +8,8 @@ general:
     - AnimatedArchitecture
 redstone:
   allow_redstone: false
+  powerblock_types:
+    - GOLD_BLOCK
 animations:
   load_chunks_for_toggle: true
   skip_animations_by_default: true
@@ -20,3 +22,13 @@ limits:
 protection_hooks:
   WorldGuard:
     enabled: true
+structures: {}
+locale:
+  locale: en_US
+  allow_client_locale: false
+caching:
+  powerblock_cache_timeout: 120
+  head_cache_timeout: 120
+logging:
+  log_level: INFO
+  debug: false

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/LuckPerms/config.yml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/LuckPerms/config.yml
@@ -1,0 +1,1 @@
+vault-unsafe-lookups: true

--- a/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/WorldGuard/worlds/world/regions.yml
+++ b/animatedarchitecture-testing/animatedarchitecture-lightkeeper-e2e/src/test/resources/provisioning/overlay/plugins/WorldGuard/worlds/world/regions.yml
@@ -1,0 +1,15 @@
+regions:
+    animatedarchitecture_e2e_denied:
+        min: {x: 40, y: 0, z: 40}
+        max: {x: 48, y: 255, z: 48}
+        members: {}
+        flags: {build: deny, block-break: deny, block-place: deny}
+        owners: {}
+        type: cuboid
+        priority: 10
+    __global__:
+        members: {}
+        flags: {}
+        owners: {}
+        type: global
+        priority: 0

--- a/animatedarchitecture-testing/pom.xml
+++ b/animatedarchitecture-testing/pom.xml
@@ -20,7 +20,6 @@
     <modules>
         <module>animatedarchitecture-integration-test-lib</module>
         <module>animatedarchitecture-integration-test</module>
-        <module>animatedarchitecture-lightkeeper-e2e</module>
     </modules>
 
     <dependencies>

--- a/animatedarchitecture-testing/pom.xml
+++ b/animatedarchitecture-testing/pom.xml
@@ -36,4 +36,13 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>lightkeeper-e2e</id>
+            <modules>
+                <module>animatedarchitecture-lightkeeper-e2e</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/animatedarchitecture-testing/pom.xml
+++ b/animatedarchitecture-testing/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>animatedarchitecture-integration-test-lib</module>
         <module>animatedarchitecture-integration-test</module>
+        <module>animatedarchitecture-lightkeeper-e2e</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
Initial and experimental approach towards full E2E integration tests using [LightKeeper](https://github.com/PimvanderLoos/LightKeeper).

Note that this will not yet compile, as I haven't published LightKeeper to Maven Central just yet. I will do that if this project turns out well. Snapshots have been made available on [EldoNexus](https://eldonexus.de/#browse/browse:maven-snapshots:nl%2Fpim16aap2%2Flightkeeper).

Also, I was trying out Codex and Claude for this project, so still need to properly review everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localization for structure type highlight/info messages.
  - Improved recovery of animated blocks when entities load.
  - Increased reliability of tool interactions by handling left-click input asynchronously with a longer timeout.
  - Enforced WorldGuard region restrictions during structure creation.

- **Tests**
  - Added LightKeeper-based end-to-end integration coverage for AnimatedArchitecture portcullis and menu workflows on both Paper and Spigot, including protection scenarios.

- **Chores**
  - Refined CI workflow permissions, documentation publishing, and end-to-end test caching/diagnostics handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->