### PR TITLE
⚡ Bolt: Optimize Math.pow calls for vector logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ ignoredFiles
 *.sh
 
 **/delombok/*
+.jules/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid Math.pow(x, 2) for simple squaring
+**Learning:** In highly mathematical or performance-critical sections (like calculating distances or radii for animations running per tick), using `Math.pow(x, 2)` incurs unnecessary method call overhead and native implementation logic designed for arbitrary floating-point exponents. Squaring by direct multiplication `x * x` is significantly faster.
+**Action:** Always use direct multiplication `x * x` instead of `Math.pow(x, 2)` in tight loops or math utility classes.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-05-24 - Avoid Math.pow(x, 2) for simple squaring
-**Learning:** In highly mathematical or performance-critical sections (like calculating distances or radii for animations running per tick), using `Math.pow(x, 2)` incurs unnecessary method call overhead and native implementation logic designed for arbitrary floating-point exponents. Squaring by direct multiplication `x * x` is significantly faster.
-**Action:** Always use direct multiplication `x * x` instead of `Math.pow(x, 2)` in tight loops or math utility classes.

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/bigdoor/BigDoorAnimationComponent.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/bigdoor/BigDoorAnimationComponent.java
@@ -139,7 +139,7 @@ public class BigDoorAnimationComponent implements IAnimationComponent
     {
         final double deltaA = rotationPoint.xD() - xAxis;
         final double deltaB = rotationPoint.zD() - zAxis;
-        return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
+        return (float) Math.sqrt((deltaA * deltaA) + (deltaB * deltaB));
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/clock/Clock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/clock/Clock.java
@@ -44,7 +44,7 @@ public class Clock implements IStructureComponent
         // The clock needs to be an odd-sized square, so the radius is always half the height (rounded up).
         final int circleRadius = MathUtil.ceil(cuboid.getDimensions().y() / 2.0D);
         // The distance to the corner of the box around the circle is just pythagoras with a == b.
-        final int boxRadius = MathUtil.ceil(Math.sqrt(2 * Math.pow(circleRadius, 2)));
+        final int boxRadius = MathUtil.ceil(Math.sqrt(2 * (circleRadius * circleRadius)));
         final int delta = boxRadius - circleRadius;
 
         return (isNorthSouthAnimated(structure) ?

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/drawbridge/DrawbridgeAnimationComponent.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/types/drawbridge/DrawbridgeAnimationComponent.java
@@ -141,7 +141,7 @@ public class DrawbridgeAnimationComponent implements IAnimationComponent
         // When the rotation point is positioned along the NS axis, the Z values does not change.
         final double deltaA = rotationPoint.yD() - yAxis;
         final double deltaB = northSouthAligned ? (rotationPoint.zD() - zAxis) : (rotationPoint.xD() - xAxis);
-        return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
+        return (float) Math.sqrt((deltaA * deltaA) + (deltaB * deltaB));
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/IVector3D.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/IVector3D.java
@@ -91,7 +91,10 @@ public sealed interface IVector3D permits Vector3Dd, Vector3Di
     @Contract(pure = true)
     default double magnitude()
     {
-        return Math.sqrt(Math.pow(xD(), 2) + Math.pow(yD(), 2) + Math.pow(zD(), 2));
+        final double x = xD();
+        final double y = yD();
+        final double z = zD();
+        return Math.sqrt((x * x) + (y * y) + (z * z));
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3DUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3DUtil.java
@@ -17,7 +17,10 @@ final class Vector3DUtil
     @Contract(pure = true)
     static double getDistance(double x0, double y0, double z0, double x1, double y1, double z1)
     {
-        return Math.sqrt(Math.pow(x0 - x1, 2) + Math.pow(y0 - y1, 2) + Math.pow(z0 - z1, 2));
+        final double dx = x0 - x1;
+        final double dy = y0 - y1;
+        final double dz = z0 - z1;
+        return Math.sqrt((dx * dx) + (dy * dy) + (dz * dz));
     }
 
     @CheckReturnValue


### PR DESCRIPTION
💡 What: Replaced `Math.pow(val, 2)` with direct multiplication `val * val` across 3D vector and animation classes.
🎯 Why: `Math.pow` involves JVM and native overhead to support arbitrary floating point exponents, which slows down frequent calculations in tight animation loops and vector distance checks.
📊 Impact: Expected microscopic CPU usage reduction per distance/radius check. Since these are called multiple times per server tick across all animated structures, the cumulative savings helps reduce main-thread tick lag.
🔬 Measurement: Can be verified by running micro-benchmarks or analyzing server tick profiles before and after for operations involving large structures like BigDoors or Clocks. Also run `mvn test` to ensure calculations remain identical.

---
*PR created automatically by Jules for task [17164549919590880135](https://jules.google.com/task/17164549919590880135) started by @PimvanderLoos*