### PR TITLE
Use JDK 25 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Cache local Maven repository
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Cache local Maven repository
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ follow these steps:
 
 Compilation requirements:
 
-* Java 21+
+* Java 25+
 * Maven
 
 You can then compile the project by running the following command in this directory:

--- a/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
+++ b/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <project.root-dir>${project.basedir}/../../..</project.root-dir>
 
+        <version.guice>5.1.0</version.guice>
         <version.plotsquared>6.11.1</version.plotsquared>
     </properties>
 
@@ -88,6 +89,13 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${version.guice}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,8 @@
 # Explicitly specify the JDK version to use + use the latest version of Maven
 before_install:
   - sdk update
-  - sdk install java 21-tem
-  - sdk default java 21-tem
+  - sdk install java 25-tem
+  - sdk default java 25-tem
   - sdk install maven
 install:
   - JAVA_HOME=~/.sdkman/candidates/java/current/ ~/.sdkman/candidates/maven/current/bin/mvn -v


### PR DESCRIPTION
Apparently, WorldEdit now uses JDK 25 for its latest release: #1285
Guess we might as well bump our minimum required compilation JDK version as well.

Output still targets 21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build, setup, and publishing environments to use JDK 25.
  * Improved compatibility with the latest Java development environment.
  * Updated project compilation requirements to Java 25 or later.
  * Added required dependency support for the PlotSquared 6 integration.
  * Maven build and installation processes remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->