### PR TITLE
Revert "Update dependency com.google.inject:guice to v7"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,6 +60,15 @@
       "matchPackageNames": [
         "/^nl\\.pim16aap2\\.animatedarchitecture:/"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "com.google.inject:guice"
+      ],
+      "matchFileNames": [
+        "animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml"
+      ],
+      "enabled": false
     }
   ],
   "ignoreDeps": [

--- a/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
+++ b/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.root-dir>${project.basedir}/../../..</project.root-dir>
 
-        <version.guice>7.0.0</version.guice>
+        <version.guice>5.1.0</version.guice>
         <version.plotsquared>6.11.1</version.plotsquared>
     </properties>
 


### PR DESCRIPTION
Reverts PimvanderLoos/AnimatedArchitecture#1323

PlotSquared 6 uses Guice 5.1.0 specifically, so we should lock to that version specifically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->